### PR TITLE
feat/product-and-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Status: design kickoff / early scaffold.
 
+## v0.0.9
+
+### Added or Changed
+- Added a backend code-review report for the issue #10 product-and-safety feature slice.
+- Documented remaining review findings around transactional relationship writes, service-role configuration, route/service test coverage, and product discovery defaults.
+- Updated the README version marker from `v0.0.8` to `v0.0.9`.
+- Added detailed version documentation at `docs/version-0.0.9-docs.md`.
+
+### For Deletion
+- None from this task context.
+
 ## v0.0.8
 
 ### Added or Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Status: design kickoff / early scaffold.
 
+## v0.0.8
+
+### Added or Changed
+- Added the initial FastAPI product-and-safety backend feature slice under `app/backend/`.
+- Added product routes for listing food, fetching food details, and seller-owned create, update, and delete operations.
+- Added safety routes for allergen catalog reads, admin-owned allergen creation, and current-user allergy profile management.
+- Added product, allergen, and user-allergy Pydantic models.
+- Added a product service layer for allergen validation, safe-for-current-user matching, seller ownership checks, and stable client-facing database error messages.
+- Hardened backend JWT handling by using a backend-only `JWT_SECRET_KEY` and revalidating token role claims against the current database user role.
+- Added backend authentication regression tests for forged-token rejection and role-mismatch rejection.
+- Updated the backend environment sample with Supabase and JWT settings.
+- Updated the README version marker from `v0.0.7` to `v0.0.8`.
+- Updated README setup, current-state, backend API, and roadmap sections for the committed backend API scaffold.
+- Added detailed version documentation at `docs/version-0.0.8-docs.md`.
+
+### For Deletion
+- None from this task context.
+
 ## v0.0.7
 
 ### Added or Changed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <p align="center">
     <strong>A web platform concept for Sureplus Philippines, focused on rescuing edible surplus food, supporting responsible inedible-food recycling, and tracking social impact.</strong>
     <br />
-    Version: v0.0.7
+    Version: v0.0.8
     <br />
     Status: design kickoff / early scaffold.
     <br />
@@ -38,6 +38,7 @@
         <li><a href="#product-scope">Product Scope</a></li>
         <li><a href="#key-features">Key Features</a></li>
         <li><a href="#data-model-highlights">Data Model Highlights</a></li>
+        <li><a href="#backend-api-highlights">Backend API Highlights</a></li>
         <li><a href="#current-repository-state">Current Repository State</a></li>
       </ul>
     </li>
@@ -105,11 +106,26 @@ Innovator, composter, recycling-request, and direct messaging entities described
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+### Backend API Highlights
+
+The backend scaffold under `app/backend/` now includes FastAPI routes and service-layer support for:
+
+- authentication and current-user context,
+- user profile lookup,
+- product listing discovery and seller-owned product management,
+- allergen catalog reads and admin-owned allergen creation,
+- current-user allergy profile reads and updates,
+- allergy-aware product responses that expose matched allergens and safe-for-current-user status.
+
+The backend uses the local Supabase schema as its persistence layer, includes a service-role client for server-side database operations, and signs application JWTs with a backend-only secret rather than the Supabase anon key. Focused regression tests cover forged-token rejection and database-role mismatch rejection in the authentication dependency.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
 ### Current Repository State
 
-This repository is currently at the design kickoff and early scaffold stage. Backend and frontend environment sample placeholders exist under `sureplus-app/backend/.sample.env` and `sureplus-app/frontend/.sample.env`, and the local Supabase project skeleton is now committed under `app/supabase/` with the initial database migration and Row Level Security policies. The runnable web application and committed dependency manifests for the frontend and backend stacks are not yet present. Add framework-specific setup steps after the frontend or backend stack is committed.
+This repository is currently at the backend scaffold stage. The local Supabase project skeleton is committed under `app/supabase/` with the initial database migration and Row Level Security policies, and `app/backend/` now contains the FastAPI backend, dependency manifest, environment sample, authentication routes, user routes, product/safety routes, service modules, Pydantic models, and focused authentication regression tests. A committed frontend application is not yet present.
 
-Refer to `SUPABASE_SETUP.md` at the repository root for the local-development onboarding flow that runs Supabase entirely on Docker without requiring a hosted Supabase account. Detailed version documentation for the database-layer and onboarding-guide additions is available in `docs/version-0.0.7-docs.md`, and earlier version notes are tracked under the other `docs/version-*-docs.md` files and in `CHANGELOG.md`.
+Refer to `SUPABASE_SETUP.md` at the repository root for the local-development onboarding flow that runs Supabase entirely on Docker without requiring a hosted Supabase account. Detailed version documentation for the product-and-safety backend additions is available in `docs/version-0.0.8-docs.md`, and earlier version notes are tracked under the other `docs/version-*-docs.md` files and in `CHANGELOG.md`.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -121,7 +137,8 @@ Refer to `SUPABASE_SETUP.md` at the repository root for the local-development on
 - A code editor
 - Docker Desktop, kept running before any `supabase` command is used
 - Supabase CLI (via Homebrew on macOS or `npm install -g supabase` on Windows or Linux)
-- Project-specific runtime dependencies, once the frontend or backend implementation stack is added
+- Python 3.11+ for the FastAPI backend
+- Backend dependencies from `app/backend/requirements.txt`
 
 ### Local Setup
 
@@ -137,9 +154,9 @@ Refer to `SUPABASE_SETUP.md` at the repository root for the local-development on
    ```sh
    dir
    ```
-4. Review the current backend and frontend environment sample placeholders.
+4. Review the current backend environment sample.
    ```powershell
-   Get-ChildItem -Force sureplus-app -Recurse -Filter .sample.env
+   Get-Content app/backend/.sample.env
    ```
 5. Bring up the local Supabase stack and apply the initial schema. See `SUPABASE_SETUP.md` for the full walkthrough; the short form is:
    ```sh
@@ -147,7 +164,16 @@ Refer to `SUPABASE_SETUP.md` at the repository root for the local-development on
    supabase start
    supabase db reset
    ```
-6. Add stack-specific install, run, and environment-variable setup commands when the frontend or backend implementation is committed.
+6. Install backend dependencies and run the FastAPI backend from the backend directory.
+   ```powershell
+   cd ../backend
+   python -m pip install -r requirements.txt
+   python -m uvicorn main:app --reload
+   ```
+7. Run the focused backend regression tests after dependencies are installed.
+   ```powershell
+   python -m unittest discover tests
+   ```
 
 For PowerShell users, the repository can be opened from the project root:
 
@@ -163,13 +189,14 @@ code .
 
 - [ ] Convert the design kickoff into reviewed requirements, user stories, and acceptance criteria.
 - [ ] Commit the initial frontend application scaffold.
-- [ ] Implement role-based registration, login, onboarding, and profile management.
-- [ ] Implement seller food-listing workflows with allergens, inventory, expiration, and product formats.
+- [x] Add the initial FastAPI backend scaffold with authentication, user, product, allergen, and user-allergy routes.
+- [ ] Complete role-based onboarding and profile management beyond the current authentication and user-profile baseline.
+- [ ] Complete seller food-listing workflows with transactional allergen updates, inventory workflows, expiration behavior, and product formats.
 - [ ] Implement buyer discovery, purchase, receipt, points, and rating flows.
 - [ ] Implement charity, innovator, composter, and admin workflows.
 - [ ] Add notification, messaging, social-impact, analytics, and leaderboard outputs.
 - [x] Commit the initial Supabase database migration with Row Level Security policies for the 17 baseline tables.
-- [ ] Add additional database migrations, validation rules, tests, deployment notes, and operations guidance.
+- [ ] Add additional database migrations, transactional safety operations, broader tests, deployment notes, and operations guidance.
 
 See the [open issues](https://github.com/Code-DER/sureplus-app/issues) for proposed features and known gaps.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <p align="center">
     <strong>A web platform concept for Sureplus Philippines, focused on rescuing edible surplus food, supporting responsible inedible-food recycling, and tracking social impact.</strong>
     <br />
-    Version: v0.0.8
+    Version: v0.0.9
     <br />
     Status: design kickoff / early scaffold.
     <br />
@@ -125,7 +125,7 @@ The backend uses the local Supabase schema as its persistence layer, includes a 
 
 This repository is currently at the backend scaffold stage. The local Supabase project skeleton is committed under `app/supabase/` with the initial database migration and Row Level Security policies, and `app/backend/` now contains the FastAPI backend, dependency manifest, environment sample, authentication routes, user routes, product/safety routes, service modules, Pydantic models, and focused authentication regression tests. A committed frontend application is not yet present.
 
-Refer to `SUPABASE_SETUP.md` at the repository root for the local-development onboarding flow that runs Supabase entirely on Docker without requiring a hosted Supabase account. Detailed version documentation for the product-and-safety backend additions is available in `docs/version-0.0.8-docs.md`, and earlier version notes are tracked under the other `docs/version-*-docs.md` files and in `CHANGELOG.md`.
+Refer to `SUPABASE_SETUP.md` at the repository root for the local-development onboarding flow that runs Supabase entirely on Docker without requiring a hosted Supabase account. Detailed version documentation for the product-and-safety backend additions is available in `docs/version-0.0.8-docs.md`, with follow-up backend review notes summarized in `docs/version-0.0.9-docs.md` and the repository code-review documentation.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/app/backend/.sample.env
+++ b/app/backend/.sample.env
@@ -1,0 +1,6 @@
+SUPABASE_URL=http://localhost:54321
+SUPABASE_ANON_KEY=<your-local-anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<your-local-service-role-key>
+JWT_SECRET_KEY=<your-backend-only-jwt-secret>
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_TIME_MINUTES=30

--- a/app/backend/api/auth.py
+++ b/app/backend/api/auth.py
@@ -1,6 +1,5 @@
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException
 from models.user import UserResponse, UserSignUp, UserLogin, Token
-from database import supabase
 from services import auth_service
 
 router = APIRouter()
@@ -18,7 +17,7 @@ async def signup(user_input: UserSignUp):
 @router.post("/login", response_model=Token)
 async def login(user_input: UserLogin):
     # Check if the email exists in the database
-    response = supabase.table("User").select("*").eq("emailAddress", user_input.emailAddress).execute()
+    response = auth_service.fetch_user_by_email(user_input.emailAddress)
 
     # If the email does not exist, raise an error
     if not response.data:

--- a/app/backend/api/dependency.py
+++ b/app/backend/api/dependency.py
@@ -1,9 +1,18 @@
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer
 import jwt
 import os
 
+from services import auth_service
+
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
+
+
+def _get_jwt_secret() -> str:
+    secret_key = os.getenv("JWT_SECRET_KEY")
+    if not secret_key:
+        raise HTTPException(status_code=500, detail="Authentication configuration is incomplete.")
+    return secret_key
 
 # To be used as a dependency in routes that require authentication.
 # It decodes the JWT token and returns the userID and role of the logged in user.
@@ -11,16 +20,24 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
 def get_current_user(token: str = Depends(oauth2_scheme)):
     try:
         # Decode the JWT token to get the userID and role
-        payload = jwt.decode(token, os.getenv("SUPABASE_ANON_KEY"), algorithms=[os.getenv("ALGORITHM")])
+        payload = jwt.decode(
+            token,
+            _get_jwt_secret(),
+            algorithms=[os.getenv("ALGORITHM", "HS256")],
+        )
         user_id: str = payload.get("sub")
-        role: str = payload.get("role")
+        token_role: str = payload.get("role")
 
         # Raise an error if the userID or role is missing
-        if user_id is None:
+        if user_id is None or token_role is None:
             raise HTTPException(status_code=401, detail="Could not validate credentials!")
-        
+
+        user_context = auth_service.fetch_user_auth_context(user_id)
+        if not user_context or user_context.get("role") != token_role:
+            raise HTTPException(status_code=401, detail="Could not validate credentials!")
+
         # Return the userID and role
-        return {"userID": user_id, "role": role}
+        return {"userID": user_context["userID"], "role": user_context["role"]}
     except jwt.PyJWTError:
         # Raise an error if there is an error in decoding the token
         raise HTTPException(status_code=401, detail="Could not validate credentials!")

--- a/app/backend/api/products.py
+++ b/app/backend/api/products.py
@@ -1,0 +1,65 @@
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from api.dependency import get_current_user
+from models.product import FoodCreate, FoodResponse, FoodUpdate
+from services import product_service
+
+router = APIRouter()
+
+
+def require_seller(current_user: dict) -> str:
+    if current_user["role"] != "seller":
+        raise HTTPException(status_code=403, detail="Seller access is required.")
+    return current_user["userID"]
+
+
+@router.get("/", response_model=List[FoodResponse])
+async def list_foods(
+    safe_for_me: bool = Query(False),
+    edible_only: Optional[bool] = Query(None),
+    include_expired: bool = Query(True),
+    seller_id: Optional[UUID] = Query(None),
+    current_user: dict = Depends(get_current_user),
+):
+    return product_service.list_foods(
+        user_id=current_user["userID"],
+        safe_for_user=safe_for_me,
+        edible_only=edible_only,
+        include_expired=include_expired,
+        seller_id=str(seller_id) if seller_id else None,
+    )
+
+
+@router.post("/", response_model=FoodResponse)
+async def create_food(food_input: FoodCreate, current_user: dict = Depends(get_current_user)):
+    seller_id = require_seller(current_user)
+    return product_service.create_food(seller_id, food_input.model_dump(mode="json"))
+
+
+@router.get("/{food_id}", response_model=FoodResponse)
+async def get_food(food_id: UUID, current_user: dict = Depends(get_current_user)):
+    return product_service.get_food(str(food_id), user_id=current_user["userID"])
+
+
+@router.patch("/{food_id}", response_model=FoodResponse)
+async def update_food(
+    food_id: UUID,
+    food_input: FoodUpdate,
+    current_user: dict = Depends(get_current_user),
+):
+    seller_id = require_seller(current_user)
+    return product_service.update_food(
+        seller_id,
+        str(food_id),
+        food_input.model_dump(exclude_unset=True, mode="json"),
+    )
+
+
+@router.delete("/{food_id}")
+async def delete_food(food_id: UUID, current_user: dict = Depends(get_current_user)):
+    seller_id = require_seller(current_user)
+    product_service.delete_food(seller_id, str(food_id))
+    return {"message": "Food listing deleted."}

--- a/app/backend/api/safety.py
+++ b/app/backend/api/safety.py
@@ -1,0 +1,55 @@
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.dependency import get_current_user
+from models.product import AllergenCreate, AllergenResponse, UserAllergiesResponse, UserAllergiesUpdate
+from services import product_service
+
+router = APIRouter()
+
+
+def require_admin(current_user: dict) -> None:
+    if current_user["role"] != "admin":
+        raise HTTPException(status_code=403, detail="Admin access is required.")
+
+
+@router.get("/allergens", response_model=List[AllergenResponse])
+async def list_allergens():
+    return product_service.list_allergens()
+
+
+@router.post("/allergens", response_model=AllergenResponse)
+async def create_allergen(
+    allergen_input: AllergenCreate,
+    current_user: dict = Depends(get_current_user),
+):
+    require_admin(current_user)
+    return product_service.create_allergen(allergen_input.model_dump())
+
+
+@router.get("/me/allergies", response_model=UserAllergiesResponse)
+async def get_my_allergies(current_user: dict = Depends(get_current_user)):
+    return product_service.get_user_allergies(current_user["userID"])
+
+
+@router.put("/me/allergies", response_model=UserAllergiesResponse)
+async def replace_my_allergies(
+    allergy_input: UserAllergiesUpdate,
+    current_user: dict = Depends(get_current_user),
+):
+    return product_service.replace_user_allergies(
+        current_user["userID"],
+        allergy_input.allergenIDs,
+    )
+
+
+@router.post("/me/allergies/{allergen_id}", response_model=UserAllergiesResponse)
+async def add_my_allergy(allergen_id: UUID, current_user: dict = Depends(get_current_user)):
+    return product_service.add_user_allergy(current_user["userID"], str(allergen_id))
+
+
+@router.delete("/me/allergies/{allergen_id}", response_model=UserAllergiesResponse)
+async def remove_my_allergy(allergen_id: UUID, current_user: dict = Depends(get_current_user)):
+    return product_service.remove_user_allergy(current_user["userID"], str(allergen_id))

--- a/app/backend/database.py
+++ b/app/backend/database.py
@@ -6,5 +6,7 @@ load_dotenv()
 
 url: str = os.environ.get("SUPABASE_URL")
 key: str = os.environ.get("SUPABASE_ANON_KEY")
+service_key: str = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
 
 supabase: Client = create_client(url, key)
+supabase_admin: Client = create_client(url, service_key or key)

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -1,12 +1,16 @@
 from fastapi import FastAPI
 from api.users import router as users_router
 from api.auth import router as auth_router
+from api.products import router as products_router
+from api.safety import router as safety_router
 
 app = FastAPI(title="SurePlus API")
 
 # Routers for the app
 app.include_router(users_router, prefix="/users", tags=["Users"])
 app.include_router(auth_router, prefix="/auth", tags=["Authentication"])
+app.include_router(products_router, prefix="/products", tags=["Products"])
+app.include_router(safety_router, prefix="/safety", tags=["Safety"])
 
 # Root endpoint
 @app.get("/")

--- a/app/backend/models/product.py
+++ b/app/backend/models/product.py
@@ -1,0 +1,64 @@
+from datetime import date, datetime
+from decimal import Decimal
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class AllergenBase(BaseModel):
+    name: str = Field(..., min_length=1)
+
+
+class AllergenCreate(AllergenBase):
+    pass
+
+
+class AllergenResponse(AllergenBase):
+    allergenID: UUID
+
+
+class FoodBase(BaseModel):
+    foodName: str = Field(..., min_length=1)
+    description: Optional[str] = None
+    picture: Optional[str] = None
+    isEdible: bool = True
+    price: Decimal = Field(..., ge=0)
+    stockQuantity: int = Field(..., ge=0)
+    expirationDate: Optional[date] = None
+
+
+class FoodCreate(FoodBase):
+    description: str = Field(..., min_length=1)
+    picture: str = Field(..., min_length=1)
+    expirationDate: date
+    allergenIDs: List[UUID] = Field(default_factory=list)
+
+
+class FoodUpdate(BaseModel):
+    foodName: Optional[str] = Field(default=None, min_length=1)
+    description: Optional[str] = Field(default=None, min_length=1)
+    picture: Optional[str] = Field(default=None, min_length=1)
+    isEdible: Optional[bool] = None
+    price: Optional[Decimal] = Field(default=None, ge=0)
+    stockQuantity: Optional[int] = Field(default=None, ge=0)
+    expirationDate: Optional[date] = None
+    allergenIDs: Optional[List[UUID]] = None
+
+
+class FoodResponse(FoodBase):
+    foodID: UUID
+    userID: UUID
+    createdAt: Optional[datetime] = None
+    allergens: List[AllergenResponse] = Field(default_factory=list)
+    isSafeForCurrentUser: Optional[bool] = None
+    matchedAllergenIDs: List[UUID] = Field(default_factory=list)
+
+
+class UserAllergiesUpdate(BaseModel):
+    allergenIDs: List[UUID] = Field(default_factory=list)
+
+
+class UserAllergiesResponse(BaseModel):
+    userID: UUID
+    allergens: List[AllergenResponse] = Field(default_factory=list)

--- a/app/backend/services/auth_service.py
+++ b/app/backend/services/auth_service.py
@@ -1,5 +1,5 @@
 from passlib.context import CryptContext
-from database import supabase
+from database import supabase_admin
 from fastapi import HTTPException
 import jwt
 import os
@@ -10,6 +10,15 @@ load_dotenv()
 
 # Context for password hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Function to load the backend-only JWT secret
+def get_jwt_secret():
+    secret_key = os.getenv("JWT_SECRET_KEY")
+
+    if not secret_key:
+        raise ValueError("JWT_SECRET_KEY is missing from .env")
+
+    return secret_key
 
 # Function to hash the password
 def hash_password(password: str):
@@ -26,7 +35,7 @@ def hash_password(password: str):
 # Function to create a new user
 def create_user(user_data: dict):
     # Check if email exists
-    existing = supabase.table("User").select("emailAddress").eq("emailAddress", user_data["emailAddress"]).execute()
+    existing = supabase_admin.table("User").select("emailAddress").eq("emailAddress", user_data["emailAddress"]).execute()
     if existing.data:
         raise HTTPException(status_code=400, detail="Email already registered!")
     
@@ -34,7 +43,7 @@ def create_user(user_data: dict):
     user_data['password'] = hash_password(user_data['password'])
 
     # Insert user into User Table
-    user_response = supabase.table("User").insert(user_data).execute()
+    user_response = supabase_admin.table("User").insert(user_data).execute()
 
     # Check if user creation was successful
     if not user_response.data:
@@ -44,18 +53,52 @@ def create_user(user_data: dict):
     new_user = user_response.data[0]
     new_user_id = new_user['userID']
 
-    # Create an entry on the Buyer Table if the user is a buyer
+    # Create an entry on the role extension table for the new user.
     if new_user.get('role') == 'buyer':
         buyer_data = {
             "userID": new_user_id,
             "points": 0
         }
-        buyer_response = supabase.table("Buyer").insert(buyer_data).execute()
+        buyer_response = supabase_admin.table("Buyer").insert(buyer_data).execute()
 
         if not buyer_response.data:
             raise HTTPException(status_code=500, detail="Failed to create buyer!")
+    elif new_user.get('role') == 'seller':
+        seller_response = supabase_admin.table("Seller").insert({"userID": new_user_id}).execute()
+
+        if not seller_response.data:
+            raise HTTPException(status_code=500, detail="Failed to create seller!")
+    elif new_user.get('role') == 'charity':
+        charity_response = supabase_admin.table("Charity").insert({"userID": new_user_id}).execute()
+
+        if not charity_response.data:
+            raise HTTPException(status_code=500, detail="Failed to create charity!")
+    elif new_user.get('role') == 'admin':
+        admin_response = supabase_admin.table("Admin").insert({"userID": new_user_id}).execute()
+
+        if not admin_response.data:
+            raise HTTPException(status_code=500, detail="Failed to create admin!")
 
     return new_user
+
+# Function to fetch a user by email during login
+def fetch_user_by_email(email_address: str):
+    return supabase_admin.table("User").select("*").eq("emailAddress", email_address).execute()
+
+# Function to fetch the current authorization context from the database
+def fetch_user_auth_context(user_id: str):
+    response = (
+        supabase_admin.table("User")
+        .select("userID, role")
+        .eq("userID", user_id)
+        .limit(1)
+        .execute()
+    )
+
+    if not response.data:
+        return None
+
+    return response.data[0]
 
 # Function to verify the password
 def verify_password(plain_password: str, hashed_password: str):
@@ -67,13 +110,9 @@ def create_access_token(data: dict):
     to_encode = data.copy()
 
     # Get the keys, algorithm, and expiry time from the env
-    secret_key = os.getenv("SUPABASE_ANON_KEY")
+    secret_key = get_jwt_secret()
     algorithm = os.getenv("ALGORITHM", "HS256")
     expire_time = int(os.getenv("ACCESS_TOKEN_EXPIRE_TIME_MINUTES", "30"))
-
-    # Raise an error if secret key is missing
-    if not secret_key:
-        raise ValueError("Secret Key is missing from .env")
     
     # Calcualte the expiry time 
     expire = datetime.now(timezone.utc) + timedelta(minutes=expire_time)

--- a/app/backend/services/product_service.py
+++ b/app/backend/services/product_service.py
@@ -1,0 +1,300 @@
+import logging
+from datetime import date
+from typing import Dict, Iterable, List, Optional, Set
+
+from fastapi import HTTPException
+
+from database import supabase_admin
+
+
+logger = logging.getLogger(__name__)
+
+FOOD_COLUMNS = (
+    "foodID, userID, foodName, description, picture, isEdible, "
+    "price, stockQuantity, expirationDate, createdAt"
+)
+ALLERGEN_COLUMNS = "allergenID, name"
+
+
+def _execute(query, error_detail: str):
+    try:
+        return query.execute()
+    except Exception as exc:
+        logger.exception(error_detail)
+        raise HTTPException(status_code=500, detail=error_detail) from exc
+
+
+def _dedupe(values: Iterable) -> List[str]:
+    seen: Set[str] = set()
+    deduped: List[str] = []
+    for value in values:
+        value_str = str(value)
+        if value_str not in seen:
+            seen.add(value_str)
+            deduped.append(value_str)
+    return deduped
+
+
+def _fetch_allergen_map(allergen_ids: Iterable) -> Dict[str, dict]:
+    ids = _dedupe(allergen_ids)
+    if not ids:
+        return {}
+
+    response = _execute(
+        supabase_admin.table("Allergen").select(ALLERGEN_COLUMNS).in_("allergenID", ids),
+        "Failed to fetch allergens",
+    )
+    return {str(row["allergenID"]): row for row in response.data or []}
+
+
+def _validate_allergen_ids(allergen_ids: Iterable) -> List[str]:
+    ids = _dedupe(allergen_ids)
+    allergen_map = _fetch_allergen_map(ids)
+    missing_ids = [allergen_id for allergen_id in ids if allergen_id not in allergen_map]
+
+    if missing_ids:
+        raise HTTPException(
+            status_code=404,
+            detail={"message": "Some allergens were not found.", "allergenIDs": missing_ids},
+        )
+
+    return ids
+
+
+def _fetch_food_allergen_rows(food_ids: Iterable) -> List[dict]:
+    ids = _dedupe(food_ids)
+    if not ids:
+        return []
+
+    response = _execute(
+        supabase_admin.table("FoodAllergen").select("foodID, allergenID").in_("foodID", ids),
+        "Failed to fetch food allergens",
+    )
+    return response.data or []
+
+
+def _fetch_user_allergen_ids(user_id: str) -> Set[str]:
+    response = _execute(
+        supabase_admin.table("UserAllergies").select("allergenID").eq("userID", user_id),
+        "Failed to fetch user allergies",
+    )
+    return {str(row["allergenID"]) for row in response.data or []}
+
+
+def _attach_allergens(food_rows: List[dict], user_id: Optional[str] = None) -> List[dict]:
+    food_ids = [row["foodID"] for row in food_rows]
+    relation_rows = _fetch_food_allergen_rows(food_ids)
+    allergen_map = _fetch_allergen_map(row["allergenID"] for row in relation_rows)
+    user_allergen_ids = _fetch_user_allergen_ids(user_id) if user_id else set()
+
+    relations_by_food: Dict[str, List[dict]] = {}
+    for row in relation_rows:
+        relations_by_food.setdefault(str(row["foodID"]), []).append(row)
+
+    enriched_food = []
+    for food in food_rows:
+        food_id = str(food["foodID"])
+        relations = relations_by_food.get(food_id, [])
+        allergen_ids = [str(row["allergenID"]) for row in relations]
+        matched_ids = sorted(set(allergen_ids).intersection(user_allergen_ids))
+
+        enriched = dict(food)
+        enriched["allergens"] = [
+            allergen_map[allergen_id]
+            for allergen_id in allergen_ids
+            if allergen_id in allergen_map
+        ]
+        enriched["matchedAllergenIDs"] = matched_ids
+        enriched["isSafeForCurrentUser"] = len(matched_ids) == 0 if user_id else None
+        enriched_food.append(enriched)
+
+    return enriched_food
+
+
+def list_foods(
+    user_id: Optional[str] = None,
+    safe_for_user: bool = False,
+    edible_only: Optional[bool] = None,
+    include_expired: bool = True,
+    seller_id: Optional[str] = None,
+) -> List[dict]:
+    query = supabase_admin.table("Food").select(FOOD_COLUMNS)
+
+    if edible_only is not None:
+        query = query.eq("isEdible", edible_only)
+    if seller_id:
+        query = query.eq("userID", seller_id)
+    if not include_expired:
+        query = query.gte("expirationDate", date.today().isoformat())
+
+    response = _execute(query.order("createdAt", desc=True), "Failed to fetch food listings")
+    foods = _attach_allergens(response.data or [], user_id=user_id)
+
+    if safe_for_user and user_id:
+        foods = [food for food in foods if food["isSafeForCurrentUser"]]
+
+    return foods
+
+
+def get_food(food_id: str, user_id: Optional[str] = None) -> dict:
+    response = _execute(
+        supabase_admin.table("Food").select(FOOD_COLUMNS).eq("foodID", food_id).limit(1),
+        "Failed to fetch food listing",
+    )
+
+    if not response.data:
+        raise HTTPException(status_code=404, detail="Food listing not found.")
+
+    return _attach_allergens([response.data[0]], user_id=user_id)[0]
+
+
+def create_food(seller_id: str, food_data: dict) -> dict:
+    allergen_ids = _validate_allergen_ids(food_data.pop("allergenIDs", []))
+    food_data["userID"] = seller_id
+
+    response = _execute(
+        supabase_admin.table("Food").insert(food_data),
+        "Failed to create food listing",
+    )
+
+    if not response.data:
+        raise HTTPException(status_code=500, detail="Failed to create food listing.")
+
+    food = response.data[0]
+    if allergen_ids:
+        rows = [
+            {"foodID": food["foodID"], "allergenID": allergen_id}
+            for allergen_id in allergen_ids
+        ]
+        _execute(
+            supabase_admin.table("FoodAllergen").insert(rows),
+            "Failed to attach food allergens",
+        )
+
+    return get_food(food["foodID"], user_id=seller_id)
+
+
+def update_food(seller_id: str, food_id: str, food_data: dict) -> dict:
+    existing_food = get_food(food_id)
+    if str(existing_food["userID"]) != str(seller_id):
+        raise HTTPException(status_code=403, detail="You can only update your own food listings.")
+
+    allergen_ids = food_data.pop("allergenIDs", None)
+    update_data = {key: value for key, value in food_data.items() if value is not None}
+
+    if not update_data and allergen_ids is None:
+        raise HTTPException(status_code=400, detail="No food listing changes were provided.")
+
+    if update_data:
+        response = _execute(
+            supabase_admin.table("Food").update(update_data).eq("foodID", food_id),
+            "Failed to update food listing",
+        )
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Food listing not found.")
+
+    if allergen_ids is not None:
+        validated_allergen_ids = _validate_allergen_ids(allergen_ids)
+        _execute(
+            supabase_admin.table("FoodAllergen").delete().eq("foodID", food_id),
+            "Failed to replace food allergens",
+        )
+        if validated_allergen_ids:
+            rows = [
+                {"foodID": food_id, "allergenID": allergen_id}
+                for allergen_id in validated_allergen_ids
+            ]
+            _execute(
+                supabase_admin.table("FoodAllergen").insert(rows),
+                "Failed to attach food allergens",
+            )
+
+    return get_food(food_id, user_id=seller_id)
+
+
+def delete_food(seller_id: str, food_id: str) -> None:
+    existing_food = get_food(food_id)
+    if str(existing_food["userID"]) != str(seller_id):
+        raise HTTPException(status_code=403, detail="You can only delete your own food listings.")
+
+    _execute(
+        supabase_admin.table("Food").delete().eq("foodID", food_id),
+        "Failed to delete food listing",
+    )
+
+
+def list_allergens() -> List[dict]:
+    response = _execute(
+        supabase_admin.table("Allergen").select(ALLERGEN_COLUMNS).order("name"),
+        "Failed to fetch allergens",
+    )
+    return response.data or []
+
+
+def create_allergen(allergen_data: dict) -> dict:
+    response = _execute(
+        supabase_admin.table("Allergen").insert(allergen_data),
+        "Failed to create allergen",
+    )
+
+    if not response.data:
+        raise HTTPException(status_code=500, detail="Failed to create allergen.")
+
+    return response.data[0]
+
+
+def get_user_allergies(user_id: str) -> dict:
+    allergy_rows = _execute(
+        supabase_admin.table("UserAllergies").select("allergenID").eq("userID", user_id),
+        "Failed to fetch user allergies",
+    ).data or []
+    allergen_map = _fetch_allergen_map(row["allergenID"] for row in allergy_rows)
+
+    return {
+        "userID": user_id,
+        "allergens": list(allergen_map.values()),
+    }
+
+
+def replace_user_allergies(user_id: str, allergen_ids: Iterable) -> dict:
+    ids = _validate_allergen_ids(allergen_ids)
+
+    _execute(
+        supabase_admin.table("UserAllergies").delete().eq("userID", user_id),
+        "Failed to replace user allergies",
+    )
+
+    if ids:
+        rows = [{"userID": user_id, "allergenID": allergen_id} for allergen_id in ids]
+        _execute(
+            supabase_admin.table("UserAllergies").insert(rows),
+            "Failed to save user allergies",
+        )
+
+    return get_user_allergies(user_id)
+
+
+def add_user_allergy(user_id: str, allergen_id: str) -> dict:
+    _validate_allergen_ids([allergen_id])
+    existing_ids = _fetch_user_allergen_ids(user_id)
+
+    if allergen_id not in existing_ids:
+        _execute(
+            supabase_admin.table("UserAllergies").insert(
+                {"userID": user_id, "allergenID": allergen_id}
+            ),
+            "Failed to save user allergy",
+        )
+
+    return get_user_allergies(user_id)
+
+
+def remove_user_allergy(user_id: str, allergen_id: str) -> dict:
+    _execute(
+        supabase_admin.table("UserAllergies")
+        .delete()
+        .eq("userID", user_id)
+        .eq("allergenID", allergen_id),
+        "Failed to remove user allergy",
+    )
+    return get_user_allergies(user_id)

--- a/app/backend/tests/test_auth_dependency.py
+++ b/app/backend/tests/test_auth_dependency.py
@@ -1,0 +1,89 @@
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import jwt
+from fastapi import HTTPException
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+os.environ.setdefault("SUPABASE_URL", "http://localhost:54321")
+os.environ.setdefault("SUPABASE_ANON_KEY", "test-anon-key")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key")
+os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret")
+os.environ.setdefault("ALGORITHM", "HS256")
+
+from api import dependency  # noqa: E402
+
+
+def make_token(secret: str, role: str = "seller") -> str:
+    payload = {
+        "sub": "00000000-0000-0000-0000-000000000001",
+        "role": role,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+class AuthDependencyTests(unittest.TestCase):
+    def test_rejects_token_signed_with_supabase_anon_key(self):
+        with patch.dict(os.environ, {"JWT_SECRET_KEY": "private-test-secret"}):
+            forged_token = make_token("test-anon-key", role="admin")
+
+            with self.assertRaises(HTTPException) as context:
+                dependency.get_current_user(token=forged_token)
+
+        self.assertEqual(context.exception.status_code, 401)
+
+    def test_rejects_token_role_that_does_not_match_database(self):
+        token = make_token("private-test-secret", role="admin")
+
+        with (
+            patch.dict(os.environ, {"JWT_SECRET_KEY": "private-test-secret"}),
+            patch.object(
+                dependency.auth_service,
+                "fetch_user_auth_context",
+                return_value={
+                    "userID": "00000000-0000-0000-0000-000000000001",
+                    "role": "seller",
+                },
+            ),
+            self.assertRaises(HTTPException) as context,
+        ):
+            dependency.get_current_user(token=token)
+
+        self.assertEqual(context.exception.status_code, 401)
+
+    def test_accepts_token_role_that_matches_database(self):
+        token = make_token("private-test-secret", role="seller")
+
+        with (
+            patch.dict(os.environ, {"JWT_SECRET_KEY": "private-test-secret"}),
+            patch.object(
+                dependency.auth_service,
+                "fetch_user_auth_context",
+                return_value={
+                    "userID": "00000000-0000-0000-0000-000000000001",
+                    "role": "seller",
+                },
+            ),
+        ):
+            current_user = dependency.get_current_user(token=token)
+
+        self.assertEqual(
+            current_user,
+            {
+                "userID": "00000000-0000-0000-0000-000000000001",
+                "role": "seller",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/code-review/scrutinize-app-backend--issue-10.md
+++ b/docs/code-review/scrutinize-app-backend--issue-10.md
@@ -1,0 +1,242 @@
+# Backend Product and Safety Review - Issue 10
+
+## Quick Diagnostic Read
+
+This report reviews the `app/backend` product-and-safety implementation for issue #10 after the authentication hardening update. Issue #10 is scoped to the `Food`, `Allergen`, `FoodAllergen`, and `UserAllergies` data model surfaces.
+
+The review focused on:
+
+- FastAPI route registration and route-level authorization for product and safety endpoints.
+- JWT verification, role revalidation, and backend Supabase client configuration.
+- Product, allergen, food-allergen, and user-allergy service behavior.
+- Available backend test coverage for the new product and safety workflows.
+
+No runtime tests, HTTP requests, database connections, linter runs, or static analyzers were executed as part of this report. The findings below are based on static code review.
+
+## One-Sentence Objective
+
+Decide whether the issue #10 backend slice is ready for integration, identify confirmed risks, and name the smallest follow-up actions needed before merge.
+
+## Why This Area Matters
+
+The `app/backend` package owns authentication, product listing management, allergen catalog management, and allergy-aware filtering. For issue #10, the largest behavioral risk is dietary-safety correctness: if `FoodAllergen` or `UserAllergies` state is incomplete or stale, food that should be unsafe for a user can appear safe.
+
+Authorization also matters because sellers can create and update inventory, admins can create allergens, and the service layer performs server-side writes against tables protected by Row Level Security policies.
+
+## Review Surface
+
+Primary files:
+
+- `app/backend/main.py`
+- `app/backend/api/products.py`
+- `app/backend/api/safety.py`
+- `app/backend/api/auth.py`
+- `app/backend/api/dependency.py`
+- `app/backend/database.py`
+- `app/backend/services/product_service.py`
+- `app/backend/services/auth_service.py`
+- `app/backend/models/product.py`
+- `app/backend/tests/test_auth_dependency.py`
+
+Supporting context:
+
+- `app/backend/.sample.env`
+- `app/backend/requirements.txt`
+- `app/supabase/migrations/20260425000000_initial_schema.sql`
+
+## Entry Points, Trust Boundaries, And Test Surfaces
+
+Entry points:
+
+- `main.py` registers `/users`, `/auth`, `/products`, and `/safety`.
+- `api/products.py` exposes listing, create, get, patch, and delete operations for food records.
+- `api/safety.py` exposes allergen catalog reads and writes plus current-user allergy management.
+- `api/auth.py` exposes signup and login, and issues bearer tokens consumed by protected routes.
+
+Trust boundaries:
+
+- `api/dependency.py` verifies application JWTs using `JWT_SECRET_KEY`, requires `sub` and `role`, and re-fetches the current database role before returning an authenticated user context.
+- `api/products.py` gates product writes to sellers.
+- `api/safety.py` gates allergen creation to admins.
+- `database.py` constructs both anon and server-side Supabase clients.
+- `product_service.py` performs product, allergen, and user-allergy writes through the server-side client.
+
+Test surfaces:
+
+- `tests/test_auth_dependency.py` covers anon-key-signed token rejection, token/database role mismatch rejection, and matched-role success.
+- No tests currently exercise product routes, safety routes, product service behavior, user-allergy replacement, safe-for-user filtering, service-role configuration failure, expired listing behavior, or zero-stock listing behavior.
+
+## Findings Ordered By Severity
+
+### Critical
+
+No Critical findings were confirmed.
+
+### High
+
+No High findings remain confirmed.
+
+The previous JWT trust-boundary concern is addressed by signing and verifying application tokens with `JWT_SECRET_KEY` and by revalidating the token role against the current database user role before protected route logic runs.
+
+### Medium
+
+#### M1. Multi-step product and allergy writes can leave partial dietary-safety state
+
+Confidence: confirmed design defect.
+
+Locations:
+
+- `app/backend/services/product_service.py`
+- `app/supabase/migrations/20260425000000_initial_schema.sql`
+
+Observed fact:
+
+`create_food` inserts a `Food` row and then separately inserts `FoodAllergen` rows. `update_food` deletes `FoodAllergen` rows and then separately inserts replacements. `replace_user_allergies` deletes all `UserAllergies` rows and then separately inserts replacements. These operations are not wrapped in a transaction or database RPC.
+
+Impact:
+
+If the second request fails after the first request succeeds, a food listing can be missing allergen tags, or a user can temporarily or permanently lose allergy rows. Since safe-for-user filtering depends on those relationships, partial state can create false-safe product results.
+
+Smallest safe fix direction:
+
+Move relationship replacement into transaction-backed Postgres RPC functions such as `create_food_with_allergens`, `replace_food_allergens`, and `replace_user_allergies`, then call those RPCs from `product_service.py`.
+
+Validating test/check:
+
+Add a failure-injection test where relationship insert fails after parent insert/delete and verify the prior safety state remains intact or the whole operation rolls back.
+
+#### M2. `supabase_admin` silently falls back to the anon key when the service-role key is missing
+
+Confidence: confirmed defect.
+
+Locations:
+
+- `app/backend/database.py`
+- `app/backend/.sample.env`
+- `app/supabase/migrations/20260425000000_initial_schema.sql`
+
+Observed fact:
+
+`database.py` reads `SUPABASE_SERVICE_ROLE_KEY`, but constructs `supabase_admin` with `service_key or key`. If `SUPABASE_SERVICE_ROLE_KEY` is absent, the backend silently uses `SUPABASE_ANON_KEY` for the admin client. The issue #10 service methods then call `supabase_admin` for writes.
+
+Impact:
+
+With a missing service-role key, product and user-allergy writes are likely to fail under RLS because the anon client does not carry the authenticated user's Supabase JWT and the schema policies depend on `auth.uid()`. The application starts successfully, but issue #10 writes fail later and unclearly.
+
+Smallest safe fix direction:
+
+Fail fast during backend startup or configuration loading if `SUPABASE_URL`, `SUPABASE_ANON_KEY`, or `SUPABASE_SERVICE_ROLE_KEY` is missing. Do not silently downgrade `supabase_admin` to anon privileges.
+
+Validating test/check:
+
+Add a config test that clears `SUPABASE_SERVICE_ROLE_KEY` and asserts database client setup fails with an explicit configuration error before route handlers run.
+
+#### M3. Product and safety route/service behavior remains mostly untested
+
+Confidence: confirmed validation gap.
+
+Locations:
+
+- `app/backend/tests/test_auth_dependency.py`
+- `app/backend/api/products.py`
+- `app/backend/api/safety.py`
+- `app/backend/services/product_service.py`
+
+Observed fact:
+
+The current tests cover the authentication dependency only. They do not cover `/products`, `/safety`, seller/admin route gates, safe-for-user filtering, allergen ID validation through service methods, product ownership checks, duplicate allergen behavior, service-role missing-env behavior, or partial relationship-write failures.
+
+Impact:
+
+The highest-risk authentication boundary has direct regression coverage, but the main issue #10 product and safety workflows can still regress without a failing test. The most important untested behavior is safe-for-user filtering fed by `FoodAllergen` and `UserAllergies`.
+
+Smallest safe fix direction:
+
+Add one route-level test module for `/products` and `/safety` with dependency overrides for buyer, seller, and admin contexts. Add one service-level test module using fake Supabase query objects for `list_foods`, `update_food`, and `replace_user_allergies`.
+
+Validating test/check:
+
+Run `python -m unittest discover app/backend/tests` in an environment with backend requirements installed and confirm route/service tests fail on authorization or safety regressions.
+
+### Low
+
+#### L1. Product discovery defaults may expose expired or unavailable listings
+
+Confidence: open question.
+
+Locations:
+
+- `app/backend/api/products.py`
+- `app/backend/services/product_service.py`
+- `app/supabase/migrations/20260425000000_initial_schema.sql`
+
+Observed fact:
+
+`list_foods` defaults `include_expired=True` and does not filter `stockQuantity > 0`. It only filters expiration when callers pass `include_expired=False`.
+
+Impact:
+
+If `/products` is intended as buyer-facing discovery, expired or zero-stock foods can appear by default. If it is intended as a seller/admin catalog endpoint, the default may be acceptable. The code does not state which contract is intended.
+
+Smallest safe fix direction:
+
+Clarify endpoint semantics. For buyer discovery, add an `available_only` default that filters out expired and zero-stock listings. For seller/admin catalog use, keep broad listing behavior but expose a separate buyer discovery route.
+
+Validating test/check:
+
+Add tests for expired, null-expiration, zero-stock, and positive-stock listings under the chosen default contract.
+
+## Cross-File Contract Risks
+
+1. Protected requests now depend on database role revalidation. This is a good security tradeoff, but failure behavior and latency should be validated.
+2. `database.py` exposes `supabase_admin`, while `product_service.py` assumes it has service-role privileges. The anon-key fallback breaks that implicit contract.
+3. `models/product.py` requires `description`, `picture`, and `expirationDate` on create, while the migration permits nullable values. This stricter API contract may be intentional, but imported or legacy rows can still return null values.
+4. `auth_service.py` creates role-extension rows after inserting `User`. If a role-extension insert fails, a user can exist without the extension row expected by product or admin flows.
+5. The auth dependency tests do not prove that FastAPI route wiring rejects forged or stale-role tokens at the `/products` and `/safety` endpoints.
+
+## Security Status
+
+Primary security-sensitive regions:
+
+- JWT signing and verification in `auth_service.py` and `dependency.py`.
+- Database role revalidation in `auth_service.py` and `dependency.py`.
+- Role-gated issue #10 routes in `products.py` and `safety.py`.
+- Service-role database access in `database.py` and `product_service.py`.
+- User-sensitive allergy data in `product_service.py`.
+
+Status:
+
+- The previously identified forged-token path using `SUPABASE_ANON_KEY` is addressed in code and has direct dependency tests.
+- No new Critical or High security finding was confirmed from static evidence.
+- Residual risk is operational and data-consistency oriented: missing service-role configuration currently fails late, and multi-step relationship writes can produce partial safety state.
+
+## Top Risks
+
+1. Non-atomic allergen relationship writes can make unsafe food appear safe after partial failure.
+2. Missing service-role configuration can make issue #10 writes fail later and unclearly under RLS.
+3. Product/safety workflows still lack route and service regression coverage.
+
+## Missing Tests And Validation Gaps
+
+No route or service tests currently cover:
+
+- seller-only product writes,
+- admin-only allergen creation,
+- safe-for-user filtering,
+- allergen relationship replacement failure,
+- user-allergy replacement failure,
+- missing service-role configuration,
+- expired listing behavior,
+- zero-stock listing behavior.
+
+## Recommended Smallest Next Action
+
+Make `SUPABASE_SERVICE_ROLE_KEY` mandatory in `database.py` and fail fast instead of falling back to the anon key.
+
+## Verification Notes
+
+This report did not execute tests or runtime checks. The previously reported local verification for the implementation was:
+
+- `python -m compileall app/backend` passed.
+- `git diff --check` passed.
+- FastAPI/OpenAPI import checking could not run because the current Python environment did not have `fastapi` installed.

--- a/docs/version-0.0.8-docs.md
+++ b/docs/version-0.0.8-docs.md
@@ -1,0 +1,230 @@
+# Version v0.0.8 Documentation
+
+## Quick Diagnostic Read
+
+Version `v0.0.8` adds the first committed FastAPI backend feature slice for product inventory and dietary safety. The database schema already included the `Food`, `Allergen`, `FoodAllergen`, and `UserAllergies` tables; this version adds the API, model, and service code that starts using those tables.
+
+You are looking at the correct version if:
+
+- `README.md` shows version `v0.0.8`
+- `app/backend/main.py` registers product and safety routers
+- `app/backend/api/products.py` exists
+- `app/backend/api/safety.py` exists
+- `app/backend/models/product.py` exists
+- `app/backend/services/product_service.py` exists
+- `app/backend/tests/test_auth_dependency.py` exists
+- `app/backend/.sample.env` includes `JWT_SECRET_KEY`
+- `CHANGELOG.md` has a `v0.0.8` entry
+
+## One-Sentence Objective
+
+Version `v0.0.8` turns the product-and-safety database tables into a usable backend API surface with guarded product management, allergen management, user allergy profiles, safe-for-current-user filtering, and authentication regression coverage.
+
+## Why This Version Matters
+
+Before this version, the repository had a Supabase schema but no committed backend implementation for product listings or dietary safety. Contributors could inspect the tables, but they could not call product or allergen endpoints from the backend.
+
+This version makes the first product-and-safety backend flow concrete:
+
+- sellers can manage their own food listings through product routes,
+- users can retrieve products with allergen metadata and safe-for-current-user status,
+- users can manage their own allergy profile,
+- admins can create allergen catalog entries,
+- authentication now uses a backend-only JWT secret and rechecks the user's current database role before protected route logic runs,
+- a focused test module locks down forged-token rejection and role-mismatch rejection.
+
+## Plan A / Plan B
+
+### Plan A: Backend Smoke Verification
+
+1. Start the local Supabase stack.
+2. Apply the database migrations.
+3. Create a backend `.env` from `app/backend/.sample.env` and fill in local keys.
+4. Install backend dependencies.
+5. Start the FastAPI app with Uvicorn.
+6. Open the generated OpenAPI docs and confirm product and safety routes are present.
+
+### Plan B: Static Verification
+
+1. Open `app/backend/main.py` and confirm `/products` and `/safety` are registered.
+2. Open `app/backend/models/product.py` and review the request/response contracts.
+3. Open `app/backend/services/product_service.py` and review how allergen relationships are attached to food responses.
+4. Open `app/backend/tests/test_auth_dependency.py` and confirm the authentication dependency rejects forged and stale-role tokens.
+
+Use Plan A when you have Docker, Supabase CLI, and backend dependencies ready. Use Plan B when you only need to verify the committed code shape.
+
+## System View
+
+```text
+app/
+  backend/
+    .sample.env                         <- backend env template with JWT_SECRET_KEY
+    main.py                             <- FastAPI app and router registration
+    api/
+      auth.py                           <- signup/login routes
+      dependency.py                     <- token decoding and role revalidation
+      products.py                       <- product listing and seller-owned product routes
+      safety.py                         <- allergen catalog and current-user allergy routes
+      users.py                          <- user/profile routes
+    models/
+      product.py                        <- product, allergen, and user-allergy schemas
+      user.py                           <- user/auth schemas
+    services/
+      auth_service.py                   <- signup, login lookup, token creation, role context lookup
+      product_service.py                <- product/allergen/user-allergy Supabase operations
+      user_service.py                   <- user lookup helpers
+    tests/
+      test_auth_dependency.py           <- authentication dependency regression tests
+  supabase/
+    migrations/
+      20260425000000_initial_schema.sql <- database schema consumed by the backend
+```
+
+## What Changed In Detail
+
+### Product API Routes
+
+`app/backend/api/products.py` adds product routes under `/products`:
+
+- `GET /products/` lists food records and can include safe-for-current-user filtering.
+- `POST /products/` lets sellers create food listings.
+- `GET /products/{food_id}` fetches one listing with allergen metadata.
+- `PATCH /products/{food_id}` lets the owning seller update a listing.
+- `DELETE /products/{food_id}` lets the owning seller delete a listing.
+
+Seller-only write routes use the authenticated user context from the shared dependency and then enforce seller ownership in the service layer for updates and deletes.
+
+### Safety API Routes
+
+`app/backend/api/safety.py` adds dietary-safety routes under `/safety`:
+
+- `GET /safety/allergens` reads the allergen catalog.
+- `POST /safety/allergens` lets admins add allergen entries.
+- `GET /safety/me/allergies` returns the current user's allergies.
+- `PUT /safety/me/allergies` replaces the current user's allergy set.
+- `POST /safety/me/allergies/{allergen_id}` adds one allergy.
+- `DELETE /safety/me/allergies/{allergen_id}` removes one allergy.
+
+### Product and Safety Models
+
+`app/backend/models/product.py` defines the Pydantic contracts for:
+
+- allergen creation and responses,
+- food creation, update, and responses,
+- user allergy replacement and responses.
+
+The food models validate UUIDs, non-negative prices, non-negative stock, required listing fields on create, and typed expiration dates.
+
+### Product Service Layer
+
+`app/backend/services/product_service.py` handles the Supabase operations for product and safety data:
+
+- loads and validates allergen IDs,
+- deduplicates ID lists before relationship writes,
+- attaches allergen metadata to food responses,
+- computes `matchedAllergenIDs` and `isSafeForCurrentUser`,
+- checks seller ownership before product update/delete,
+- logs backend database errors while returning stable client-facing messages.
+
+The current implementation still performs some relationship replacement as multiple database calls. A future database migration should add transaction-backed operations for replacing food allergens and user allergies.
+
+### Authentication Hardening
+
+`app/backend/api/dependency.py` now verifies application JWTs with `JWT_SECRET_KEY` instead of the Supabase anon key. It also requires both `sub` and `role` claims, then re-fetches the user's current role from the database before route logic sees the authenticated context.
+
+`app/backend/services/auth_service.py` now creates application JWTs with `JWT_SECRET_KEY`, fetches users for login through the server-side Supabase client, and creates the matching role-extension row during signup for buyers, sellers, charities, and admins.
+
+### Regression Tests
+
+`app/backend/tests/test_auth_dependency.py` adds focused tests for:
+
+- rejecting a token signed with the Supabase anon key,
+- rejecting a token whose role claim does not match the database role,
+- accepting a token whose role matches the database role.
+
+These tests target the highest-risk authentication boundary introduced by the product-and-safety routes.
+
+## Acceptance Notes
+
+This version is ready when:
+
+- the backend code compiles with `python -m compileall app/backend`,
+- `git diff --check` reports no whitespace errors,
+- backend dependencies are installed from `app/backend/requirements.txt`,
+- `python -m unittest discover tests` passes from `app/backend`,
+- local Supabase is running and migrated,
+- `/products` and `/safety` routes appear in the FastAPI OpenAPI schema,
+- `README.md`, `CHANGELOG.md`, and this document all reference `v0.0.8`.
+
+## Verification Commands
+
+Run syntax checks from the repository root:
+
+```powershell
+python -m compileall app/backend
+git diff --check
+```
+
+Run backend tests after installing dependencies:
+
+```powershell
+cd app/backend
+python -m pip install -r requirements.txt
+python -m unittest discover tests
+```
+
+Run the backend locally after configuring `.env`:
+
+```powershell
+cd app/backend
+python -m uvicorn main:app --reload
+```
+
+## Pitfalls And Debugging
+
+### `ModuleNotFoundError: No module named 'fastapi'`
+
+Install backend dependencies from `app/backend/requirements.txt` before running the test suite or importing the app.
+
+### Authentication Fails With Configuration Error
+
+Confirm `JWT_SECRET_KEY` exists in the backend environment. This secret must be backend-only and must not be reused as the Supabase anon key.
+
+### Product Writes Fail Under Row Level Security
+
+Confirm the backend has `SUPABASE_SERVICE_ROLE_KEY` configured. The server-side product service uses a privileged Supabase client for controlled backend writes.
+
+### Safe Filtering Looks Wrong
+
+Check all three relationship surfaces:
+
+- the user's rows in `UserAllergies`,
+- the food's rows in `FoodAllergen`,
+- the allergen catalog rows in `Allergen`.
+
+If any relationship row is missing, the backend cannot identify the allergen match.
+
+## Practice Drill
+
+Add one test that proves a seller cannot update another seller's food listing.
+
+Self-check:
+
+- the test sets up one food row owned by seller A,
+- the request or service call uses seller B,
+- the backend returns a `403`,
+- the food row remains unchanged.
+
+## Mini Competency Map
+
+- Level 1: Can start the backend and see `/products` and `/safety` in OpenAPI.
+- Level 2: Can explain how `Food`, `Allergen`, `FoodAllergen`, and `UserAllergies` combine to produce safe-for-current-user output.
+- Level 3: Can write service tests for product ownership and allergen filtering.
+- Level 4: Can implement transaction-backed relationship replacement and prove rollback behavior with tests.
+
+## Next 24-72 Hours
+
+1. Install backend dependencies and run the authentication regression tests.
+2. Add product/safety route tests for buyer, seller, and admin access.
+3. Add transaction-backed database operations for replacing food allergens and user allergies.
+4. Decide whether `/products` should hide expired or zero-stock listings by default for buyer discovery.

--- a/docs/version-0.0.9-docs.md
+++ b/docs/version-0.0.9-docs.md
@@ -1,0 +1,124 @@
+# Version v0.0.9 Documentation
+
+## Quick Diagnostic Read
+
+Version `v0.0.9` adds a public backend code-review report for the issue #10 product-and-safety feature slice. The implementation itself landed in `v0.0.8`; this version records the follow-up review findings and the next recommended hardening step.
+
+You are looking at the correct version if:
+
+- `README.md` shows version `v0.0.9`
+- `CHANGELOG.md` has a `v0.0.9` entry
+- the repository contains a backend code-review report for issue #10 under `docs/code-review/`
+
+## One-Sentence Objective
+
+Version `v0.0.9` documents the remaining product-and-safety backend risks after the issue #10 implementation, so follow-up work can focus on data consistency, configuration failure behavior, and regression coverage.
+
+## Why This Version Matters
+
+The issue #10 backend slice introduced product inventory routes, allergen routes, user allergy management, safe-for-current-user filtering, and hardened JWT role validation. After that implementation, the most important remaining questions are not whether the routes exist, but whether the safety relationships stay consistent when writes fail and whether the workflows have enough test coverage.
+
+This version makes those follow-up findings explicit:
+
+- multi-step product and allergy relationship writes should move behind transaction-backed database operations,
+- `SUPABASE_SERVICE_ROLE_KEY` should be mandatory instead of falling back to the anon key,
+- product and safety routes need regression tests beyond the current authentication dependency tests,
+- product discovery defaults should be clarified for expired and zero-stock listings.
+
+## Plan A / Plan B
+
+### Plan A: Hardening Follow-Up
+
+1. Update backend configuration loading so `SUPABASE_SERVICE_ROLE_KEY` is required.
+2. Add a focused configuration test that fails when the service-role key is absent.
+3. Move food-allergen and user-allergy replacement into transaction-backed database functions.
+4. Add route/service tests for product writes, safety writes, and safe-for-user filtering.
+
+### Plan B: Review-Only Verification
+
+1. Read the issue #10 backend report under `docs/code-review/`.
+2. Compare its findings with `app/backend/services/product_service.py` and `app/backend/database.py`.
+3. Confirm the top follow-up item is still service-role configuration fail-fast behavior.
+
+Use Plan A when making the next backend change. Use Plan B when triaging or planning the next issue.
+
+## System View
+
+```text
+docs/
+  code-review/
+    ...issue-10.md            <- backend product-and-safety review report
+  version-0.0.9-docs.md       <- this version note
+README.md                     <- version marker and documentation pointer
+CHANGELOG.md                  <- v0.0.9 summary
+```
+
+## What Changed In Detail
+
+### Backend Review Report
+
+The new backend review report records the post-implementation state of the issue #10 product-and-safety backend slice.
+
+It confirms that no Critical or High findings remain after the JWT trust-boundary fix. It also records three Medium findings:
+
+- product/allergy writes remain multi-step and non-transactional,
+- `supabase_admin` silently falls back to the anon key when `SUPABASE_SERVICE_ROLE_KEY` is missing,
+- product and safety route/service behavior lacks direct regression coverage.
+
+The report also records one Low open question: whether default `/products` listing behavior should include expired or zero-stock listings.
+
+### README And Changelog Updates
+
+`README.md` now marks the repository as `v0.0.9` and points readers to the new follow-up documentation. `CHANGELOG.md` now includes a `v0.0.9` entry summarizing the review artifact and the remaining review findings.
+
+## Acceptance Notes
+
+This version is ready when:
+
+- `README.md` references `v0.0.9`,
+- `CHANGELOG.md` has a `v0.0.9` entry,
+- the backend review report exists under `docs/code-review/`,
+- `git diff --check` reports no whitespace errors.
+
+## Verification Commands
+
+Run whitespace checks from the repository root:
+
+```powershell
+git diff --check
+git diff --staged --check
+```
+
+The change is documentation-only, so backend tests are not required for this version update. Backend tests should be run before merging the next code change that addresses the review findings.
+
+## Pitfalls And Debugging
+
+### Product Safety Looks Correct In Code But Fails In Data
+
+Check whether `FoodAllergen` and `UserAllergies` replacement writes are still split across multiple requests. Without transaction-backed writes, a partial failure can leave safety metadata incomplete.
+
+### Product Writes Fail Under Row Level Security
+
+Confirm `SUPABASE_SERVICE_ROLE_KEY` is configured. The current follow-up recommendation is to make this key mandatory so failures happen at startup instead of during product or safety writes.
+
+### Route Behavior Regresses Without Test Failure
+
+Add route-level tests for `/products` and `/safety`, then add service-level tests for safe-for-user filtering and relationship replacement behavior.
+
+## Practice Drill
+
+Add a test that proves backend startup or database-client configuration fails clearly when `SUPABASE_SERVICE_ROLE_KEY` is missing.
+
+Self-check:
+
+- the test clears the service-role key,
+- database client setup raises a clear configuration error,
+- the error mentions the missing key,
+- the code no longer falls back to `SUPABASE_ANON_KEY` for the server-side client.
+
+## Mini Competency Map
+
+- Level 1: Can explain why the review report has no remaining High findings.
+- Level 2: Can describe how partial allergen writes can create false-safe food results.
+- Level 3: Can design a transaction-backed replacement flow for food allergens and user allergies.
+- Level 4: Can write regression tests that prove product/safety routes reject unauthorized access and preserve dietary-safety state.


### PR DESCRIPTION
For Issue #10 

# Backend Product and Safety Review - Issue 10

## Quick Diagnostic Read

This report reviews the `app/backend` product-and-safety implementation for issue #10 after the authentication hardening update. Issue #10 is scoped to the `Food`, `Allergen`, `FoodAllergen`, and `UserAllergies` data model surfaces.

The review focused on:

- FastAPI route registration and route-level authorization for product and safety endpoints.
- JWT verification, role revalidation, and backend Supabase client configuration.
- Product, allergen, food-allergen, and user-allergy service behavior.
- Available backend test coverage for the new product and safety workflows.

No runtime tests, HTTP requests, database connections, linter runs, or static analyzers were executed as part of this report. The findings below are based on static code review.

## One-Sentence Objective

Decide whether the issue #10 backend slice is ready for integration, identify confirmed risks, and name the smallest follow-up actions needed before merge.

## Why This Area Matters

The `app/backend` package owns authentication, product listing management, allergen catalog management, and allergy-aware filtering. For issue #10, the largest behavioral risk is dietary-safety correctness: if `FoodAllergen` or `UserAllergies` state is incomplete or stale, food that should be unsafe for a user can appear safe.

Authorization also matters because sellers can create and update inventory, admins can create allergens, and the service layer performs server-side writes against tables protected by Row Level Security policies.

## Review Surface

Primary files:

- `app/backend/main.py`
- `app/backend/api/products.py`
- `app/backend/api/safety.py`
- `app/backend/api/auth.py`
- `app/backend/api/dependency.py`
- `app/backend/database.py`
- `app/backend/services/product_service.py`
- `app/backend/services/auth_service.py`
- `app/backend/models/product.py`
- `app/backend/tests/test_auth_dependency.py`

Supporting context:

- `app/backend/.sample.env`
- `app/backend/requirements.txt`
- `app/supabase/migrations/20260425000000_initial_schema.sql`

## Entry Points, Trust Boundaries, And Test Surfaces

Entry points:

- `main.py` registers `/users`, `/auth`, `/products`, and `/safety`.
- `api/products.py` exposes listing, create, get, patch, and delete operations for food records.
- `api/safety.py` exposes allergen catalog reads and writes plus current-user allergy management.
- `api/auth.py` exposes signup and login, and issues bearer tokens consumed by protected routes.

Trust boundaries:

- `api/dependency.py` verifies application JWTs using `JWT_SECRET_KEY`, requires `sub` and `role`, and re-fetches the current database role before returning an authenticated user context.
- `api/products.py` gates product writes to sellers.
- `api/safety.py` gates allergen creation to admins.
- `database.py` constructs both anon and server-side Supabase clients.
- `product_service.py` performs product, allergen, and user-allergy writes through the server-side client.

Test surfaces:

- `tests/test_auth_dependency.py` covers anon-key-signed token rejection, token/database role mismatch rejection, and matched-role success.
- No tests currently exercise product routes, safety routes, product service behavior, user-allergy replacement, safe-for-user filtering, service-role configuration failure, expired listing behavior, or zero-stock listing behavior.

## Findings Ordered By Severity

### Critical

No Critical findings were confirmed.

### High

No High findings remain confirmed.

The previous JWT trust-boundary concern is addressed by signing and verifying application tokens with `JWT_SECRET_KEY` and by revalidating the token role against the current database user role before protected route logic runs.

### Medium

#### M1. Multi-step product and allergy writes can leave partial dietary-safety state

Confidence: confirmed design defect.

Locations:

- `app/backend/services/product_service.py`
- `app/supabase/migrations/20260425000000_initial_schema.sql`

Observed fact:

`create_food` inserts a `Food` row and then separately inserts `FoodAllergen` rows. `update_food` deletes `FoodAllergen` rows and then separately inserts replacements. `replace_user_allergies` deletes all `UserAllergies` rows and then separately inserts replacements. These operations are not wrapped in a transaction or database RPC.

Impact:

If the second request fails after the first request succeeds, a food listing can be missing allergen tags, or a user can temporarily or permanently lose allergy rows. Since safe-for-user filtering depends on those relationships, partial state can create false-safe product results.

Smallest safe fix direction:

Move relationship replacement into transaction-backed Postgres RPC functions such as `create_food_with_allergens`, `replace_food_allergens`, and `replace_user_allergies`, then call those RPCs from `product_service.py`.

Validating test/check:

Add a failure-injection test where relationship insert fails after parent insert/delete and verify the prior safety state remains intact or the whole operation rolls back.

#### M2. `supabase_admin` silently falls back to the anon key when the service-role key is missing

Confidence: confirmed defect.

Locations:

- `app/backend/database.py`
- `app/backend/.sample.env`
- `app/supabase/migrations/20260425000000_initial_schema.sql`

Observed fact:

`database.py` reads `SUPABASE_SERVICE_ROLE_KEY`, but constructs `supabase_admin` with `service_key or key`. If `SUPABASE_SERVICE_ROLE_KEY` is absent, the backend silently uses `SUPABASE_ANON_KEY` for the admin client. The issue #10 service methods then call `supabase_admin` for writes.

Impact:

With a missing service-role key, product and user-allergy writes are likely to fail under RLS because the anon client does not carry the authenticated user's Supabase JWT and the schema policies depend on `auth.uid()`. The application starts successfully, but issue #10 writes fail later and unclearly.

Smallest safe fix direction:

Fail fast during backend startup or configuration loading if `SUPABASE_URL`, `SUPABASE_ANON_KEY`, or `SUPABASE_SERVICE_ROLE_KEY` is missing. Do not silently downgrade `supabase_admin` to anon privileges.

Validating test/check:

Add a config test that clears `SUPABASE_SERVICE_ROLE_KEY` and asserts database client setup fails with an explicit configuration error before route handlers run.

#### M3. Product and safety route/service behavior remains mostly untested

Confidence: confirmed validation gap.

Locations:

- `app/backend/tests/test_auth_dependency.py`
- `app/backend/api/products.py`
- `app/backend/api/safety.py`
- `app/backend/services/product_service.py`

Observed fact:

The current tests cover the authentication dependency only. They do not cover `/products`, `/safety`, seller/admin route gates, safe-for-user filtering, allergen ID validation through service methods, product ownership checks, duplicate allergen behavior, service-role missing-env behavior, or partial relationship-write failures.

Impact:

The highest-risk authentication boundary has direct regression coverage, but the main issue #10 product and safety workflows can still regress without a failing test. The most important untested behavior is safe-for-user filtering fed by `FoodAllergen` and `UserAllergies`.

Smallest safe fix direction:

Add one route-level test module for `/products` and `/safety` with dependency overrides for buyer, seller, and admin contexts. Add one service-level test module using fake Supabase query objects for `list_foods`, `update_food`, and `replace_user_allergies`.

Validating test/check:

Run `python -m unittest discover app/backend/tests` in an environment with backend requirements installed and confirm route/service tests fail on authorization or safety regressions.

### Low

#### L1. Product discovery defaults may expose expired or unavailable listings

Confidence: open question.

Locations:

- `app/backend/api/products.py`
- `app/backend/services/product_service.py`
- `app/supabase/migrations/20260425000000_initial_schema.sql`

Observed fact:

`list_foods` defaults `include_expired=True` and does not filter `stockQuantity > 0`. It only filters expiration when callers pass `include_expired=False`.

Impact:

If `/products` is intended as buyer-facing discovery, expired or zero-stock foods can appear by default. If it is intended as a seller/admin catalog endpoint, the default may be acceptable. The code does not state which contract is intended.

Smallest safe fix direction:

Clarify endpoint semantics. For buyer discovery, add an `available_only` default that filters out expired and zero-stock listings. For seller/admin catalog use, keep broad listing behavior but expose a separate buyer discovery route.

Validating test/check:

Add tests for expired, null-expiration, zero-stock, and positive-stock listings under the chosen default contract.

## Cross-File Contract Risks

1. Protected requests now depend on database role revalidation. This is a good security tradeoff, but failure behavior and latency should be validated.
2. `database.py` exposes `supabase_admin`, while `product_service.py` assumes it has service-role privileges. The anon-key fallback breaks that implicit contract.
3. `models/product.py` requires `description`, `picture`, and `expirationDate` on create, while the migration permits nullable values. This stricter API contract may be intentional, but imported or legacy rows can still return null values.
4. `auth_service.py` creates role-extension rows after inserting `User`. If a role-extension insert fails, a user can exist without the extension row expected by product or admin flows.
5. The auth dependency tests do not prove that FastAPI route wiring rejects forged or stale-role tokens at the `/products` and `/safety` endpoints.

## Security Status

Primary security-sensitive regions:

- JWT signing and verification in `auth_service.py` and `dependency.py`.
- Database role revalidation in `auth_service.py` and `dependency.py`.
- Role-gated issue #10 routes in `products.py` and `safety.py`.
- Service-role database access in `database.py` and `product_service.py`.
- User-sensitive allergy data in `product_service.py`.

Status:

- The previously identified forged-token path using `SUPABASE_ANON_KEY` is addressed in code and has direct dependency tests.
- No new Critical or High security finding was confirmed from static evidence.
- Residual risk is operational and data-consistency oriented: missing service-role configuration currently fails late, and multi-step relationship writes can produce partial safety state.

## Top Risks

1. Non-atomic allergen relationship writes can make unsafe food appear safe after partial failure.
2. Missing service-role configuration can make issue #10 writes fail later and unclearly under RLS.
3. Product/safety workflows still lack route and service regression coverage.

## Missing Tests And Validation Gaps

No route or service tests currently cover:

- seller-only product writes,
- admin-only allergen creation,
- safe-for-user filtering,
- allergen relationship replacement failure,
- user-allergy replacement failure,
- missing service-role configuration,
- expired listing behavior,
- zero-stock listing behavior.

## Recommended Smallest Next Action

Make `SUPABASE_SERVICE_ROLE_KEY` mandatory in `database.py` and fail fast instead of falling back to the anon key.

## Verification Notes

This report did not execute tests or runtime checks. The previously reported local verification for the implementation was:

- `python -m compileall app/backend` passed.
- `git diff --check` passed.
- FastAPI/OpenAPI import checking could not run because the current Python environment did not have `fastapi` installed.
