### PR TITLE
feat/supabase-remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-Status: early full-stack scaffold.
+Status: remote Supabase-ready development baseline.
+
+## v0.2.0
+
+### Added or Changed
+- Updated the backend environment sample to target the hosted Sureplus Supabase project while keeping elevated keys and runtime secrets outside tracked files.
+- Made FastAPI CORS configuration environment-driven so local and deployed frontend origins can be coordinated across developers.
+- Replaced hardcoded frontend login/signup backend URLs with the shared Vite API base configuration.
+- Updated Supabase auth redirect defaults for the Vite development frontend origin.
+- Refreshed the public documentation set for the hosted-Supabase development workflow, backend-only secret handling, migration validation, and version `v0.2.0`.
+- Added detailed version documentation at `docs/version-0.2.0-docs.md`.
+
+### For Deletion
+- Local dependency, build, bytecode, and environment artifacts were observed during validation. They are ignored and should remain out of commits; remove them locally when convenient.
 
 ## v0.0.10
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 ## Adaptation and Transparency Notice
 
 This is an independent community policy for this repository.
-It is adapted from publicly available University of the Philippines (UP) documents, including the UP Quality Policy and the UP Statement of the Philosophy of Education and Graduate Attributes (approved November 28, 2019), to embody their spirit in an open-source context.
+It is adapted from publicly available University of the Philippines (UP) documents, including the UP Quality Policy and the UP Statement of the Philosophy of Education and Graduate Attributes (approved November 28, 2019), to embody their spirit in this project context.
 This adaptation does not imply UP affiliation, adoption, sponsorship, or endorsement unless explicitly stated by repository maintainers.
 
 ## Our Commitment
@@ -30,6 +30,7 @@ We aim to foster:
 - Share knowledge, mentor when possible, and collaborate constructively.
 - Consider broader social impact, accessibility, and sustainability in decisions.
 - Respect confidentiality, privacy, and responsible data handling.
+- Keep credentials, personal data, and security-sensitive setup details out of public collaboration spaces.
 
 ## Unacceptable Behavior
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Status: early Sureplus Website full-stack scaffold.
+Status: Sureplus Website remote Supabase-ready development baseline.
 
 Thanks for contributing to the Sureplus Website repository.
 This project follows values of quality, integrity, inclusion, collaboration, service, and continuous improvement.
@@ -45,9 +45,11 @@ This guide aligns contributions with these working values:
    - validation evidence (test output, logs, screenshots)
    - risks, tradeoffs, and rollback notes when relevant
 
-The current frontend scaffold lives under `app/frontend/`, the FastAPI backend lives under `app/backend/`, and the local database layer is provisioned through Supabase under `app/supabase/`. The schema migrations include Row Level Security policies and product-safety database functions; apply them with the local Supabase workflow documented in `SUPABASE_SETUP.md`.
+The current frontend scaffold lives under `app/frontend/`, the FastAPI backend lives under `app/backend/`, and the Supabase database project is defined under `app/supabase/`. The committed migrations include Row Level Security policies and product-safety database functions; apply and validate them through the hosted Supabase workflow documented in `SUPABASE_SETUP.md`. The local Docker workflow remains available when isolated database testing is needed.
 
-When you change anything that touches the database schema, add a new migration file under `app/supabase/migrations/` (use `supabase migration new <name>`) rather than editing the existing initial-schema migration in place, and confirm `supabase db reset` succeeds locally before opening a pull request. For backend changes, install `app/backend/requirements.txt` and run the relevant unittest checks. For frontend changes, use the commands defined in `app/frontend/package.json`.
+When you change anything that touches the database schema, add a new migration file under `app/supabase/migrations/` (use `supabase migration new <name>`) rather than editing the existing initial-schema migration in place. Validate the migration against a local Supabase reset when possible, then apply it to the hosted development project with `supabase db push` from a network that can reach the project database. If a migration must be applied through the Supabase SQL editor, document the validation evidence and reconcile migration history before treating the remote database as complete.
+
+For backend changes, install `app/backend/requirements.txt` and run the relevant unittest checks. For frontend changes, use the commands defined in `app/frontend/package.json`. For configuration changes, confirm backend-only Supabase keys never appear in frontend code, browser-visible configuration, logs, screenshots, public issues, or pull request text.
 
 ## Branch Naming
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,6 +2,8 @@ All Rights Reserved
 
 Copyright (c) Sureplus Website Development Team
 
+Project version context: this notice applies to Sureplus Website version 0.2.0 and subsequent repository revisions unless a later written license notice replaces it.
+
 THE CONTENTS OF THIS PROJECT ARE PROPRIETARY AND CONFIDENTIAL.
 UNAUTHORIZED COPYING, TRANSFERRING OR REPRODUCTION OF THE CONTENTS OF THIS PROJECT, VIA ANY MEDIUM IS STRICTLY PROHIBITED.
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
   <p align="center">
     <strong>A web platform concept for Sureplus Philippines, focused on rescuing edible surplus food, supporting responsible inedible-food recycling, and tracking social impact.</strong>
     <br />
-    Version: v0.0.10
+    Version: v0.2.0
     <br />
-    Status: early full-stack scaffold.
+    Status: remote Supabase-ready development baseline.
     <br />
     <a href="https://github.com/Code-DER/sureplus-app"><strong>Explore the repository</strong></a>
     <br />
@@ -39,6 +39,7 @@
         <li><a href="#key-features">Key Features</a></li>
         <li><a href="#data-model-highlights">Data Model Highlights</a></li>
         <li><a href="#backend-api-highlights">Backend API Highlights</a></li>
+        <li><a href="#remote-supabase-development">Remote Supabase Development</a></li>
         <li><a href="#current-repository-state">Current Repository State</a></li>
       </ul>
     </li>
@@ -117,17 +118,33 @@ The backend scaffold under `app/backend/` now includes FastAPI routes and servic
 - current-user allergy profile reads and updates,
 - allergy-aware product responses that expose matched allergens and safe-for-current-user status.
 
-The backend uses the local Supabase schema as its persistence layer, requires a service-role key for server-side database operations, and signs application JWTs with a backend-only secret rather than the Supabase anon key. Product-safety relationship writes now go through database RPC functions so food-allergen and user-allergy replacement can be handled atomically after the latest migrations are applied.
+The backend uses Supabase as its persistence layer, requires a backend-only elevated Supabase key for server-side database operations, and signs application JWTs with a separate backend-only secret rather than a Supabase client key. Product-safety relationship writes now go through database RPC functions so food-allergen and user-allergy replacement can be handled atomically after the latest migrations are applied.
 
 Focused regression tests cover forged-token rejection, database-role mismatch rejection, service-role configuration failure, and the product-safety service paths that call the atomic RPC functions.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+### Remote Supabase Development
+
+Version `v0.2.0` moves the shared backend target from developer-specific local Supabase instances to the hosted Sureplus Supabase project. The committed backend sample now points at the hosted Supabase URL, while secrets remain local to each developer or deployment environment.
+
+The current shared-development expectations are:
+
+- apply the committed Supabase migrations to the hosted project before running shared backend or frontend tests,
+- keep elevated Supabase keys on the backend only,
+- configure frontend requests through `VITE_API_URL` instead of hardcoded backend URLs,
+- configure backend CORS through `BACKEND_CORS_ORIGINS` for local and deployed frontend origins,
+- keep Supabase Auth redirect URLs aligned with the active frontend origin.
+
+The frontend still talks to the FastAPI backend rather than directly to Supabase for application login/signup flows. Supabase provides the hosted database, Row Level Security posture, RPC functions, and platform services behind the backend.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
 ### Current Repository State
 
-This repository is currently at the early full-stack scaffold stage. The local Supabase project skeleton is committed under `app/supabase/` with schema migrations, Row Level Security policies, and product-safety RPC functions. `app/backend/` contains the FastAPI backend, dependency manifest, environment sample, authentication routes, user routes, product/safety routes, service modules, Pydantic models, and focused backend regression tests. `app/frontend/` contains the current React/Vite frontend scaffold and application components.
+This repository is currently at the remote Supabase-ready development baseline. The Supabase project skeleton is committed under `app/supabase/` with schema migrations, Row Level Security policies, auth redirect defaults for Vite development, and product-safety RPC functions. `app/backend/` contains the FastAPI backend, dependency manifest, environment sample, authentication routes, user routes, product/safety routes, service modules, Pydantic models, configurable CORS, and focused backend regression tests. `app/frontend/` contains the React/Vite frontend scaffold, application components, and a shared API client driven by `VITE_API_URL`.
 
-Refer to `SUPABASE_SETUP.md` at the repository root for the local-development onboarding flow that runs Supabase entirely on Docker without requiring a hosted Supabase account. Detailed version documentation for the product-and-safety backend additions is available in `docs/version-0.0.8-docs.md`, with follow-up backend review notes summarized in `docs/version-0.0.9-docs.md` and backend debugging/hardening details summarized in `docs/version-0.0.10-docs.md`.
+Refer to `SUPABASE_SETUP.md` at the repository root for the shared hosted-Supabase setup path and the optional local Docker workflow. Detailed version documentation for this remote Supabase transition is available in `docs/version-0.2.0-docs.md`; prior product-and-safety backend additions are documented in `docs/version-0.0.8-docs.md`, `docs/version-0.0.9-docs.md`, and `docs/version-0.0.10-docs.md`.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -137,12 +154,13 @@ Refer to `SUPABASE_SETUP.md` at the repository root for the local-development on
 
 - Git
 - A code editor
-- Docker Desktop, kept running before any `supabase` command is used
+- Docker Desktop, required only when running the optional local Supabase stack
 - Supabase CLI (via Homebrew on macOS or `npm install -g supabase` on Windows or Linux)
 - Python 3.11+ for the FastAPI backend
 - Backend dependencies from `app/backend/requirements.txt`
+- Node.js and npm for the React/Vite frontend
 
-### Local Setup
+### Development Setup
 
 1. Clone the repository.
    ```sh
@@ -160,19 +178,26 @@ Refer to `SUPABASE_SETUP.md` at the repository root for the local-development on
    ```powershell
    Get-Content app/backend/.sample.env
    ```
-5. Bring up the local Supabase stack and apply the initial schema. See `SUPABASE_SETUP.md` for the full walkthrough; the short form is:
+5. Prepare the hosted Supabase project. See `SUPABASE_SETUP.md` for the full walkthrough; the short form is:
    ```sh
    cd app/supabase
-   supabase start
-   supabase db reset
+   supabase link --project-ref <project-ref>
+   supabase db push
    ```
-6. Install backend dependencies and run the FastAPI backend from the backend directory.
+6. Configure backend environment values from the sample, using project-specific keys from the Supabase dashboard and a strong backend JWT secret.
+7. Install backend dependencies and run the FastAPI backend from the backend directory.
    ```powershell
    cd ../backend
    python -m pip install -r requirements.txt
    python -m uvicorn main:app --reload
    ```
-7. Run the focused backend regression tests after dependencies are installed.
+8. Install frontend dependencies and run the Vite dev server from the frontend directory.
+   ```powershell
+   cd ../frontend
+   npm install
+   npm run dev
+   ```
+9. Run the focused backend regression tests after dependencies are installed.
    ```powershell
    python -m unittest discover tests
    ```
@@ -190,7 +215,7 @@ code .
 ## Roadmap
 
 - [ ] Convert the design kickoff into reviewed requirements, user stories, and acceptance criteria.
-- [ ] Commit the initial frontend application scaffold.
+- [x] Commit the initial frontend application scaffold.
 - [x] Add the initial FastAPI backend scaffold with authentication, user, product, allergen, and user-allergy routes.
 - [ ] Complete role-based onboarding and profile management beyond the current authentication and user-profile baseline.
 - [x] Add transactional database functions for product-safety relationship writes.
@@ -199,6 +224,7 @@ code .
 - [ ] Implement charity, innovator, composter, and admin workflows.
 - [ ] Add notification, messaging, social-impact, analytics, and leaderboard outputs.
 - [x] Commit the initial Supabase database migration with Row Level Security policies for the 17 baseline tables.
+- [x] Add shared hosted Supabase setup notes and remote-ready application configuration.
 - [ ] Add broader route tests, live database validation, deployment notes, and operations guidance.
 
 See the [open issues](https://github.com/Code-DER/sureplus-app/issues) for proposed features and known gaps.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Adaptation and Transparency Notice
 
 This is an independent security policy for this repository.
-It adapts publicly available principles from University of the Philippines (UP) documents, including the UP Quality Policy and the UP Statement of the Philosophy of Education and Graduate Attributes (approved November 28, 2019), to embody their spirit of quality, responsibility, and continuous improvement in an open-source setting.
+It adapts publicly available principles from University of the Philippines (UP) documents, including the UP Quality Policy and the UP Statement of the Philosophy of Education and Graduate Attributes (approved November 28, 2019), to embody their spirit of quality, responsibility, and continuous improvement in this project setting.
 This adaptation does not imply UP affiliation, adoption, sponsorship, or endorsement unless explicitly stated by repository maintainers.
 
 ## Security Principles
@@ -18,12 +18,13 @@ Our approach emphasizes:
 
 ## Supported Versions
 
-The project is in the `0.0.x` design kickoff and early scaffold stage.
-Security support is best-effort until a stable release process exists.
+The project is in the `0.2.x` remote Supabase-ready development baseline.
+Security support is best-effort until a stable production release process exists.
 
 | Version | Supported |
 | --- | --- |
-| 0.0.x | Best effort |
+| 0.2.x | Best effort |
+| 0.0.x | Historical only |
 | older | Not supported |
 
 ## Reporting a Vulnerability
@@ -53,6 +54,7 @@ Treat these product areas as security-sensitive:
 - payment methods, reward-point redemption, fees, and purchase records
 - private conversations, messages, notifications, ratings, and admin activity logs
 - charity approval, partner tagging, account deactivation, and verification workflows
+- Supabase project keys, backend-only elevated keys, database passwords, migration credentials, and application JWT signing secrets
 
 ## Response Targets
 
@@ -67,3 +69,9 @@ Complex issues may require more time; we will provide status updates during tria
 - We will coordinate disclosure timing with the reporter after a fix or mitigation is available.
 - We will credit reporters unless anonymity is requested.
 - We ask reporters to avoid privacy violations, service disruption, or data destruction during testing.
+
+## Credential Handling
+
+Never place backend-only Supabase keys, database passwords, or application JWT signing secrets in frontend code, screenshots, public issues, pull requests, or documentation. If a credential is exposed, rotate it in the Supabase dashboard or deployment environment before continuing shared testing.
+
+After rotating credentials, restart the backend process and re-run a smoke test covering signup, login, allergen loading, and one protected API route.

--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -1,6 +1,6 @@
-# SurePlus — Supabase Local Development Guide
+# SurePlus — Supabase Remote Development Guide
 
-> Complete setup guide for developers joining the project. No Supabase account required — everything runs locally via Docker.
+> Setup guide for the shared hosted Supabase development project, with an optional local Docker workflow for isolated database testing.
 
 ---
 
@@ -8,9 +8,9 @@
 
 1. [Prerequisites](#1-prerequisites)
 2. [Install Supabase CLI](#2-install-supabase-cli)
-3. [Project Setup](#3-project-setup)
-4. [Apply the Database Schema](#4-apply-the-database-schema)
-5. [Start the Local Instance](#5-start-the-local-instance)
+3. [Remote Project Setup](#3-remote-project-setup)
+4. [Apply the Hosted Database Schema](#4-apply-the-hosted-database-schema)
+5. [Optional Local Instance](#5-optional-local-instance)
 6. [Verify in Supabase Studio](#6-verify-in-supabase-studio)
 7. [Row Level Security (RLS)](#7-row-level-security-rls)
 8. [Common CLI Operations](#8-common-cli-operations)
@@ -23,9 +23,15 @@
 
 Before starting, install the following:
 
-### Docker Desktop _(required)_
+### Supabase Project Access _(required for shared development)_
 
-Supabase runs all its services (database, auth, storage, etc.) in Docker containers locally.
+- Access to the Sureplus Supabase project in the Supabase dashboard.
+- Permission to read project API keys and database connection settings.
+- Permission to run database migrations or apply reviewed SQL in the hosted project.
+
+### Docker Desktop _(optional local database testing)_
+
+Supabase can run its services (database, auth, storage, etc.) in Docker containers locally when you need an isolated database.
 
 - Download: https://www.docker.com/products/docker-desktop
 - After installing, **launch Docker Desktop and keep it running** before using any `supabase` commands.
@@ -34,12 +40,12 @@ Supabase runs all its services (database, auth, storage, etc.) in Docker contain
   docker info
   ```
 
-### Node.js v18+ _(if installing CLI via npm)_
+### Node.js v20+ _(if installing CLI via npm)_
 
 - Download: https://nodejs.org
 - Verify:
   ```bash
-  node --version   # should be v18 or higher
+  node --version   # should be v20 or higher for current Supabase CLI npm usage
   ```
 
 ### Homebrew _(macOS alternative for CLI install)_
@@ -70,20 +76,55 @@ npm install -g supabase
 supabase --version
 ```
 
-> **Note:** No login or Supabase account is needed for local development.
+---
+
+## 3. Remote Project Setup
+
+The shared development project uses the hosted Supabase project configured in the dashboard. Developers should connect the Supabase CLI to the hosted project before applying migrations:
+
+```bash
+cd app/supabase
+supabase login
+supabase link --project-ref <project-ref>
+```
+
+Use the database password from the Supabase dashboard when prompted. Do not commit or publish database passwords, backend-only elevated keys, or application JWT signing secrets.
+
+Required backend configuration values:
+
+```env
+SUPABASE_URL=https://<project-ref>.supabase.co
+SUPABASE_ANON_KEY=<dashboard anon or publishable key>
+SUPABASE_SERVICE_ROLE_KEY=<backend-only secret or service-role key>
+JWT_SECRET_KEY=<strong backend-only application secret>
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_TIME_MINUTES=30
+BACKEND_CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173
+```
+
+Frontend configuration should point to the FastAPI backend, not directly to the backend-only Supabase key:
+
+```env
+VITE_API_URL=http://localhost:8000
+```
 
 ---
 
-## 3. Apply the Database Schema
+## 4. Apply the Hosted Database Schema
 
-The migration file `20260425000000_initial_schema.sql` is already inside `supabase/migrations/`. It contains:
+The migration directory under `app/supabase/migrations/` contains the database schema, Row Level Security policies, indexes, and RPC functions required by the backend.
 
-- All 17 tables from the ERD
-- Foreign key relationships
-- Row Level Security (RLS) policies
-- Performance indexes
+From `app/supabase/`, apply migrations to the hosted project:
 
-You do **not** need to run this file manually — it is applied automatically when you run `supabase db reset` (see Step 5).
+```bash
+supabase migration list
+supabase db push --dry-run
+supabase db push
+```
+
+Use `--dry-run` first to confirm which migrations will be applied. The hosted project is ready only after the tables and RPC functions exist in Supabase Studio.
+
+If your network cannot complete the hosted Postgres connection, apply the reviewed migration SQL files through the Supabase dashboard SQL editor in chronological order. If SQL editor application is used, reconcile migration history later with the Supabase CLI before relying on `supabase migration list` as the source of truth.
 
 ### If you need to add a new migration:
 
@@ -94,9 +135,9 @@ supabase migration new your_migration_name
 
 ---
 
-## 4. Start the Local Instance
+## 5. Optional Local Instance
 
-Make sure **Docker Desktop is running**, then:
+Use the local instance when you need isolated testing without touching the hosted development database. Make sure **Docker Desktop is running**, then:
 
 ```bash
 supabase start
@@ -115,7 +156,7 @@ anon key:        <your-local-anon-key>
 service_role key: <your-local-service-role-key>
 ```
 
-> Save the `anon key` and `service_role key` — you'll need these to connect your frontend/backend.
+> Local keys are for the local stack only. Do not mix local keys with the hosted project URL.
 
 ### Apply all migrations:
 
@@ -123,19 +164,19 @@ service_role key: <your-local-service-role-key>
 supabase db reset
 ```
 
-This wipes the local database and re-runs every file in `supabase/migrations/` in chronological order. **Run this every time you pull new migration files from the repo.**
+This wipes the local database and re-runs every file in `supabase/migrations/` in chronological order. **Run this only against the local stack.**
 
 ---
 
 ## 6. Verify in Supabase Studio
 
-Open your browser and go to:
+For the hosted project, open the Supabase dashboard and verify the Table Editor and Database Functions pages. For the optional local project, open:
 
 ```
 http://localhost:54323
 ```
 
-You should see the **local Supabase Studio** dashboard with:
+You should see:
 
 - **17 tables** in the Table Editor: `User`, `Buyer`, `Seller`, `Charity`, `Admin`, `Notifications`, `CharityApplication`, `CharityPost`, `Allergen`, `Food`, `FoodAllergen`, `UserAllergies`, `Purchase`, `PurchaseItems`, `SocialImpact`, `Rating`, `AdminActivity`
 - **0 RLS warnings** in the Security Advisor (all tables have RLS enabled)
@@ -217,64 +258,68 @@ supabase logs realtime          # view realtime logs
 ### Type Generation _(optional — for TypeScript projects)_
 
 ```bash
-supabase gen types typescript --local > src/types/supabase.ts
+supabase gen types typescript --linked > src/types/supabase.ts
 ```
 
 ---
 
 ## 9. Connecting Your App
 
-Use the local keys from `supabase status` or `supabase start` output.
+The Sureplus frontend calls the FastAPI backend through `VITE_API_URL`. The backend is responsible for Supabase access and must keep elevated Supabase credentials server-side only.
 
-### JavaScript / TypeScript
+### Backend
 
-```bash
-npm install @supabase/supabase-js
-```
-
-```ts
-import { createClient } from "@supabase/supabase-js";
-
-const supabaseUrl = "http://localhost:54321";
-const supabaseAnonKey = "<your-local-anon-key>";
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
-```
-
-### Flutter
-
-```yaml
-# pubspec.yaml
-dependencies:
-  supabase_flutter: ^2.0.0
-```
-
-```dart
-await Supabase.initialize(
-  url: 'http://localhost:54321',
-  anonKey: '<your-local-anon-key>',
-);
-```
-
-> **For mobile (iOS/Android):** Replace `localhost` with your machine's local IP address (e.g., `192.168.1.x`) so the device can reach your dev machine.
-
-### Environment Variables
-
-Never hardcode keys. Use a `.env` file:
+Configure these backend values from the Supabase dashboard and deployment environment:
 
 ```env
-SUPABASE_URL=http://localhost:54321
-SUPABASE_ANON_KEY=<your-local-anon-key>
-SUPABASE_SERVICE_ROLE_KEY=<your-local-service-role-key>
+SUPABASE_URL=https://<project-ref>.supabase.co
+SUPABASE_ANON_KEY=<dashboard anon or publishable key>
+SUPABASE_SERVICE_ROLE_KEY=<backend-only secret or service-role key>
+JWT_SECRET_KEY=<strong backend-only application secret>
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_TIME_MINUTES=30
+BACKEND_CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173
 ```
 
-Add `.env` to your `.gitignore`.
+### Frontend
+
+```env
+VITE_API_URL=http://localhost:8000
+```
+
+Do not add backend-only Supabase keys to frontend configuration.
+
+### Auth Redirect URLs
+
+In the Supabase dashboard, set the development auth URL configuration to:
+
+```text
+Site URL: http://localhost:5173
+Redirect URLs:
+http://localhost:5173/**
+http://127.0.0.1:5173/**
+```
+
+Add deployed frontend URLs before production testing.
 
 ---
 
 ## 10. Troubleshooting
 
-### `supabase start` fails
+### `supabase db push` cannot connect to the hosted database
+
+- Confirm the project is linked with the correct project reference.
+- Confirm the database password is current.
+- Try from another network if direct Postgres or pooler TLS handshakes time out.
+- If blocked, apply reviewed migration SQL through the dashboard SQL editor, then reconcile migration history later.
+
+### Frontend CORS errors
+
+- Confirm `VITE_API_URL` points to the running FastAPI backend.
+- Confirm `BACKEND_CORS_ORIGINS` includes the current frontend origin.
+- Restart the backend after changing CORS configuration.
+
+### `supabase start` fails for local testing
 
 - Make sure **Docker Desktop is running**
 - Try restarting Docker, then run `supabase start` again
@@ -293,7 +338,7 @@ Add `.env` to your `.gitignore`.
 
 ### RLS blocking all queries during testing
 
-- Use the **service role key** (not anon key) in your backend/tests — it bypasses RLS
+- Use the backend-only elevated key for controlled backend/test operations that intentionally bypass RLS
 - Or temporarily disable RLS on the table via the SQL Editor in Studio (for local dev only)
 
 ### Can't connect from mobile emulator

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -8,7 +8,7 @@ Current dependency sources include:
 
 - Python backend packages listed in `app/backend/requirements.txt`
 - JavaScript frontend packages listed in `app/frontend/package.json` and locked in `app/frontend/package-lock.json`
-- Supabase local-development tooling documented in `SUPABASE_SETUP.md`
+- Supabase platform and CLI usage documented in `SUPABASE_SETUP.md`
 
 ## Bundled Code
 
@@ -16,12 +16,13 @@ No third-party source code is intentionally vendored into this repository as par
 
 ## License Review Status
 
-The project is still in an early scaffold stage. Before a public release or production deployment, maintainers should:
+The project is in a remote Supabase-ready development baseline. Before a public release or production deployment, maintainers should:
 
 - review backend and frontend dependency licenses,
 - confirm each dependency is compatible with the repository license and intended use,
 - document any required attribution notices,
 - update this file with package-specific notices when required.
+- confirm hosted-platform terms, API-key handling, and data-processing obligations are reviewed for the intended deployment context.
 
 ## Maintainer Note
 

--- a/app/backend/.sample.env
+++ b/app/backend/.sample.env
@@ -1,6 +1,7 @@
-SUPABASE_URL=http://localhost:54321
-SUPABASE_ANON_KEY=<your-local-anon-key>
-SUPABASE_SERVICE_ROLE_KEY=<your-local-service-role-key>
+SUPABASE_URL=https://efbaemfjhuaelimoztdw.supabase.co
+SUPABASE_ANON_KEY=<your-dashboard-anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<your-dashboard-service-role-key>
 JWT_SECRET_KEY=<your-backend-only-jwt-secret>
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_TIME_MINUTES=30
+BACKEND_CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from api.users import router as users_router
@@ -17,14 +19,17 @@ from api.admin_activity import router as admin_activity_router
 
 app = FastAPI(title="SurePlus API")
 
-origins = [
-    "http://localhost:5173",
-    "http://127.0.0.1:5173",
-]
+def _cors_origins() -> list[str]:
+    configured = os.getenv(
+        "BACKEND_CORS_ORIGINS",
+        "http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173",
+    )
+    return [origin.strip() for origin in configured.split(",") if origin.strip()]
+
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_origins=_cors_origins(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"]

--- a/app/frontend/src/components/Login.tsx
+++ b/app/frontend/src/components/Login.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
+import axios from 'axios';
 
+import api from '../api/apis';
 import './Login.css';
 
 interface LoginProps {
@@ -24,27 +26,20 @@ export default function Login({ onLogin, onSwitchToSignup }: LoginProps) {
       formData.append('username', email); // OAuth2 uses 'username' for email
       formData.append('password', password);
 
-      const response = await fetch('http://localhost:8000/auth/login', {
-        method: 'POST',
+      const response = await api.post('/auth/login', formData, {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: formData.toString(),
       });
 
-      const data = await response.json();
-
-      if (response.ok) {
-        console.log('Login Success:', data);
-        // Store both token and type
-        localStorage.setItem('token', data.access_token);
-        localStorage.setItem('token_type', data.token_type);
-        onLogin();
-      } else {
-        setError(data.detail || 'Login failed');
-        console.log('Login Failed:', data.detail);
-      }
+      const data = response.data;
+      console.log('Login Success:', data);
+      // Store both token and type
+      localStorage.setItem('token', data.access_token);
+      localStorage.setItem('token_type', data.token_type);
+      onLogin();
 
     } catch (error) {
-      setError('Connection error. Please try again.');
+      const detail = axios.isAxiosError(error) ? error.response?.data?.detail : undefined;
+      setError(detail || 'Connection error. Please try again.');
       console.error('Connection error:', error);
     }
   };
@@ -155,4 +150,3 @@ export default function Login({ onLogin, onSwitchToSignup }: LoginProps) {
     </div>
   );
 }
-

--- a/app/frontend/src/components/Signup.tsx
+++ b/app/frontend/src/components/Signup.tsx
@@ -1,4 +1,7 @@
 import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+import api from '../api/apis';
 import './Signup.css';
 
 interface SignupProps {
@@ -47,9 +50,9 @@ export default function Signup({ onSignup, onSwitchToLogin }: SignupProps) {
   useEffect(() => {
     const fetchAllergens = async () => {
       try {
-        const response = await fetch('http://localhost:8000/safety/allergens');
-        const data = await response.json();
-        if (response.ok && Array.isArray(data)) {
+        const response = await api.get('/safety/allergens');
+        const data = response.data;
+        if (Array.isArray(data)) {
           setAllergenList(data);
           const allergenMap: Record<string, boolean> = {};
           data.forEach((allergen: Allergen) => {
@@ -125,37 +128,20 @@ export default function Signup({ onSignup, onSwitchToLogin }: SignupProps) {
       }
 
       // Sign up user
-      const signupResponse = await fetch('http://localhost:8000/auth/signup', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(signupData),
-      });
-
-      if (!signupResponse.ok) {
-        const data = await signupResponse.json();
-        setError(data.detail || 'Signup failed. Please try again.');
-      }
+      await api.post('/auth/signup', signupData);
 
       // Auto login after signup
       const loginFormData = new URLSearchParams();
       loginFormData.append('username', formData.email);
       loginFormData.append('password', formData.password);
 
-      const loginResponse = await fetch('http://localhost:8000/auth/login', {
-        method: 'POST',
+      const loginResponse = await api.post('/auth/login', loginFormData, {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded' 
         },
-        body: loginFormData.toString(),
       });
 
-      const loginData = await loginResponse.json();
-
-      if (!loginResponse.ok) {
-        setError('Account created but login failed. Please log in manually.');
-        onSwitchToLogin();
-        return;
-      }
+      const loginData = loginResponse.data;
 
       localStorage.setItem('token', loginData.access_token);
       localStorage.setItem('token_type', loginData.token_type);
@@ -163,20 +149,21 @@ export default function Signup({ onSignup, onSwitchToLogin }: SignupProps) {
       // Save selected allergens
       const selectedAllergenIds = Object.keys(allergens).filter(id => allergens[id]);
       for (const allergenId of selectedAllergenIds) {
-        const allergyResponse = await fetch(`http://localhost:8000/safety/me/allergies/${allergenId}`, {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${loginData.access_token}`
-          },
-        });
-        if (!allergyResponse.ok) {
+        try {
+          await api.post(`/safety/me/allergies/${allergenId}`, undefined, {
+            headers: {
+              'Authorization': `Bearer ${loginData.access_token}`
+            },
+          });
+        } catch {
           console.warn(`Failed to save allergen ${allergenId}, but account was created.`);
         }
       }
 
       onSignup();
     } catch (err) {
-      setError('Connection error. Please try again.');
+      const detail = axios.isAxiosError(err) ? err.response?.data?.detail : undefined;
+      setError(detail || 'Connection error. Please try again.');
       console.error('Signup error:', err);
     } finally {
       setLoading(false);
@@ -408,4 +395,3 @@ export default function Signup({ onSignup, onSwitchToLogin }: SignupProps) {
     </div>
   );
 }
-

--- a/app/supabase/config.toml
+++ b/app/supabase/config.toml
@@ -147,9 +147,9 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:5173"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = ["http://localhost:3000", "http://localhost:5173", "http://127.0.0.1:5173"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).

--- a/docs/version-0.2.0-docs.md
+++ b/docs/version-0.2.0-docs.md
@@ -1,0 +1,149 @@
+# Version 0.2.0 Documentation
+
+## Quick Diagnostic Read
+
+Version `v0.2.0` changes Sureplus from a local-Supabase-first development setup to a remote Supabase-ready baseline for shared backend and frontend testing.
+
+This version matters if you need:
+
+- multiple developers testing against one consistent database schema,
+- backend Supabase credentials kept out of frontend code,
+- frontend API calls routed through one configurable backend base URL,
+- hosted Supabase migration and dashboard setup documented clearly.
+
+## One-Sentence Objective
+
+Make Sureplus ready for coordinated development against the hosted Supabase project while preserving the optional local Supabase workflow for isolated database testing.
+
+## Why This Version Matters
+
+The previous setup worked for one developer running a local Supabase stack, but it allowed setup drift between team members. Different local database states make backend/frontend testing unreliable because a route can pass on one machine and fail on another if migrations, keys, or redirect URLs differ.
+
+Version `v0.2.0` narrows that drift by documenting the hosted Supabase project as the shared development target and by making application configuration explicit:
+
+- backend Supabase access is controlled by environment values,
+- frontend API calls use `VITE_API_URL`,
+- backend CORS is controlled by `BACKEND_CORS_ORIGINS`,
+- Supabase auth redirect defaults align with Vite development URLs,
+- public docs describe hosted migration and verification steps.
+
+## What Changed
+
+### Backend Configuration
+
+The backend sample configuration now points at the hosted Sureplus Supabase URL and names the required runtime values:
+
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `JWT_SECRET_KEY`
+- `ALGORITHM`
+- `ACCESS_TOKEN_EXPIRE_TIME_MINUTES`
+- `BACKEND_CORS_ORIGINS`
+
+The backend still requires elevated Supabase access for server-side database operations. That key must remain backend-only.
+
+### Backend CORS
+
+FastAPI CORS origins are now read from `BACKEND_CORS_ORIGINS`. This lets developers and deployments add frontend origins without changing backend source code every time the frontend host changes.
+
+Default development origins remain:
+
+- `http://localhost:3000`
+- `http://localhost:5173`
+- `http://127.0.0.1:5173`
+
+### Frontend API Calls
+
+The login and signup flows no longer hardcode `http://localhost:8000`. They now use the shared API client, which reads `VITE_API_URL`.
+
+This makes the frontend easier to run against:
+
+- a local FastAPI backend during development,
+- a tunnel or staging backend during shared testing,
+- a deployed backend later.
+
+### Supabase Auth Redirect Defaults
+
+The Supabase configuration now defaults local auth redirects to the Vite development frontend:
+
+- Site URL: `http://localhost:5173`
+- Additional redirect URLs:
+  - `http://localhost:3000`
+  - `http://localhost:5173`
+  - `http://127.0.0.1:5173`
+
+The hosted Supabase dashboard still needs to be checked whenever frontend deployment URLs change.
+
+### Documentation Refresh
+
+The following public documents were refreshed for version `v0.2.0`:
+
+- `README.md`
+- `CHANGELOG.md`
+- `CODE_OF_CONDUCT.md`
+- `CONTRIBUTING.md`
+- `LICENSE.txt`
+- `SECURITY.md`
+- `SUPABASE_SETUP.md`
+- `THIRD-PARTY-NOTICES.md`
+
+The main documentation shift is from "local Supabase onboarding" to "hosted Supabase shared development, with local Supabase as an optional isolated workflow."
+
+## Validation Performed
+
+Automated and local checks completed for this version:
+
+```powershell
+npm run build
+```
+
+Result: frontend TypeScript/Vite build passed.
+
+```powershell
+python -m unittest discover tests
+```
+
+Result: backend tests passed with 11 tests OK.
+
+```powershell
+git diff --check
+```
+
+Result: whitespace check passed.
+
+Supabase CLI project linking completed for the hosted project, but hosted database migration commands could not complete from the current network path because the Postgres connection did not complete the TLS handshake. The fallback path is to apply reviewed migration SQL through the Supabase dashboard SQL editor, then reconcile migration history through the CLI from a network that can connect successfully.
+
+## Hosted Supabase Completion Checklist
+
+The remote Supabase setup is complete only when all of these are true:
+
+- the hosted Table Editor shows the committed tables such as `User`, `Buyer`, `Seller`, `Food`, `Allergen`, `Purchase`, and `CharityPost`,
+- the hosted Database Functions view shows the required RPC functions, including product-safety and charity amount functions,
+- Supabase Auth URL configuration includes the active frontend development and deployed origins,
+- backend runtime configuration uses current dashboard keys after any credential rotation,
+- the frontend can sign up, log in, load allergens, and call at least one protected backend route.
+
+## Operational Notes
+
+The application currently uses FastAPI-managed login/signup flows and application JWTs. Supabase is the hosted database and platform layer behind the backend. The frontend should not receive backend-only Supabase credentials.
+
+Storage buckets and Edge Functions are not part of the committed Supabase project surface in this version. If they are added later, they need explicit migration, deployment, and documentation steps.
+
+## Known Follow-Up Work
+
+Recommended next work after `v0.2.0`:
+
+1. Confirm hosted migrations through `supabase migration list` once database connectivity is available.
+2. Add a small live-environment smoke-test checklist for signup, login, product listing, allergen loading, and protected profile routes.
+3. Add deployment-specific frontend and backend environment documentation after the team chooses a hosting target.
+4. Add broader route coverage for live Supabase-backed workflows.
+
+## Self-Check
+
+You understand this version if you can answer:
+
+- Why should the frontend use `VITE_API_URL` instead of hardcoded backend URLs?
+- Why must elevated Supabase keys stay backend-only?
+- What is the difference between applying SQL through the dashboard and applying migrations with `supabase db push`?
+- Which dashboard checks prove the hosted Supabase project is ready for shared testing?


### PR DESCRIPTION
# Version 0.2.0 Documentation

## Quick Diagnostic Read

Version `v0.2.0` changes Sureplus from a local-Supabase-first development setup to a remote Supabase-ready baseline for shared backend and frontend testing.

This version matters if you need:

- multiple developers testing against one consistent database schema,
- backend Supabase credentials kept out of frontend code,
- frontend API calls routed through one configurable backend base URL,
- hosted Supabase migration and dashboard setup documented clearly.

## One-Sentence Objective

Make Sureplus ready for coordinated development against the hosted Supabase project while preserving the optional local Supabase workflow for isolated database testing.

## Why This Version Matters

The previous setup worked for one developer running a local Supabase stack, but it allowed setup drift between team members. Different local database states make backend/frontend testing unreliable because a route can pass on one machine and fail on another if migrations, keys, or redirect URLs differ.

Version `v0.2.0` narrows that drift by documenting the hosted Supabase project as the shared development target and by making application configuration explicit:

- backend Supabase access is controlled by environment values,
- frontend API calls use `VITE_API_URL`,
- backend CORS is controlled by `BACKEND_CORS_ORIGINS`,
- Supabase auth redirect defaults align with Vite development URLs,
- public docs describe hosted migration and verification steps.

## What Changed

### Backend Configuration

The backend sample configuration now points at the hosted Sureplus Supabase URL and names the required runtime values:

- `SUPABASE_URL`
- `SUPABASE_ANON_KEY`
- `SUPABASE_SERVICE_ROLE_KEY`
- `JWT_SECRET_KEY`
- `ALGORITHM`
- `ACCESS_TOKEN_EXPIRE_TIME_MINUTES`
- `BACKEND_CORS_ORIGINS`

The backend still requires elevated Supabase access for server-side database operations. That key must remain backend-only.

### Backend CORS

FastAPI CORS origins are now read from `BACKEND_CORS_ORIGINS`. This lets developers and deployments add frontend origins without changing backend source code every time the frontend host changes.

Default development origins remain:

- `http://localhost:3000`
- `http://localhost:5173`
- `http://127.0.0.1:5173`

### Frontend API Calls

The login and signup flows no longer hardcode `http://localhost:8000`. They now use the shared API client, which reads `VITE_API_URL`.

This makes the frontend easier to run against:

- a local FastAPI backend during development,
- a tunnel or staging backend during shared testing,
- a deployed backend later.

### Supabase Auth Redirect Defaults

The Supabase configuration now defaults local auth redirects to the Vite development frontend:

- Site URL: `http://localhost:5173`
- Additional redirect URLs:
  - `http://localhost:3000`
  - `http://localhost:5173`
  - `http://127.0.0.1:5173`

The hosted Supabase dashboard still needs to be checked whenever frontend deployment URLs change.

### Documentation Refresh

The following public documents were refreshed for version `v0.2.0`:

- `README.md`
- `CHANGELOG.md`
- `CODE_OF_CONDUCT.md`
- `CONTRIBUTING.md`
- `LICENSE.txt`
- `SECURITY.md`
- `SUPABASE_SETUP.md`
- `THIRD-PARTY-NOTICES.md`

The main documentation shift is from "local Supabase onboarding" to "hosted Supabase shared development, with local Supabase as an optional isolated workflow."

## Validation Performed

Automated and local checks completed for this version:

```powershell
npm run build
```

Result: frontend TypeScript/Vite build passed.

```powershell
python -m unittest discover tests
```

Result: backend tests passed with 11 tests OK.

```powershell
git diff --check
```

Result: whitespace check passed.

Supabase CLI project linking completed for the hosted project, but hosted database migration commands could not complete from the current network path because the Postgres connection did not complete the TLS handshake. The fallback path is to apply reviewed migration SQL through the Supabase dashboard SQL editor, then reconcile migration history through the CLI from a network that can connect successfully.

## Hosted Supabase Completion Checklist

The remote Supabase setup is complete only when all of these are true:

- the hosted Table Editor shows the committed tables such as `User`, `Buyer`, `Seller`, `Food`, `Allergen`, `Purchase`, and `CharityPost`,
- the hosted Database Functions view shows the required RPC functions, including product-safety and charity amount functions,
- Supabase Auth URL configuration includes the active frontend development and deployed origins,
- backend runtime configuration uses current dashboard keys after any credential rotation,
- the frontend can sign up, log in, load allergens, and call at least one protected backend route.

## Operational Notes

The application currently uses FastAPI-managed login/signup flows and application JWTs. Supabase is the hosted database and platform layer behind the backend. The frontend should not receive backend-only Supabase credentials.

Storage buckets and Edge Functions are not part of the committed Supabase project surface in this version. If they are added later, they need explicit migration, deployment, and documentation steps.

## Known Follow-Up Work

Recommended next work after `v0.2.0`:

1. Confirm hosted migrations through `supabase migration list` once database connectivity is available.
2. Add a small live-environment smoke-test checklist for signup, login, product listing, allergen loading, and protected profile routes.
3. Add deployment-specific frontend and backend environment documentation after the team chooses a hosting target.
4. Add broader route coverage for live Supabase-backed workflows.

## Self-Check

You understand this version if you can answer:

- Why should the frontend use `VITE_API_URL` instead of hardcoded backend URLs?
- Why must elevated Supabase keys stay backend-only?
- What is the difference between applying SQL through the dashboard and applying migrations with `supabase db push`?
- Which dashboard checks prove the hosted Supabase project is ready for shared testing?
