### PR TITLE
feat: admin can now verify a partner

### DIFF
--- a/app/backend/api/admin.py
+++ b/app/backend/api/admin.py
@@ -5,10 +5,11 @@ from uuid import UUID
 from database import supabase_admin
 from api.dependency import require_role
 from models.admin_reports import ReportsOverviewResponse, ReportsTransactionRow
+from models.admin_partner import SellerVerificationUpdateRequest, SellerVerificationUpdateResponse
 from models.user import AdminCreateUserRequest, UpdateUserRoleRequest
 from models.charity_post import CharityPostUpdate
 from models.charity import CharityUpdate
-from services import admin_reports_service, admin_activity_service, charity_post_service, charity_service
+from services import admin_reports_service, admin_activity_service, charity_post_service, charity_service, admin_partner_service
 from services.auth_service import hash_password
 
 router = APIRouter()
@@ -356,6 +357,37 @@ async def update_seller_tags(
         print(f"Warning: Failed to record admin activity: {e}")
 
     return {"message": "Tags updated", "tags": tags}
+
+
+@router.put("/sellers/{seller_id}/verification", response_model=SellerVerificationUpdateResponse)
+async def update_seller_verification(
+    seller_id: UUID,
+    payload: SellerVerificationUpdateRequest,
+    current_user: dict = Depends(require_role("admin")),
+):
+    updated_seller = admin_partner_service.update_seller_verification(
+        seller_id=str(seller_id),
+        is_verified=payload.isVerified,
+    )
+    if not updated_seller:
+        raise HTTPException(status_code=404, detail="Seller not found")
+
+    try:
+        admin_activity_service.record_admin_activity(
+            admin_id=current_user["userID"],
+            action_type="verify_seller" if payload.isVerified else "unverify_seller",
+            description=f"{'Verified' if payload.isVerified else 'Unverified'} seller account",
+            target_id=str(seller_id),
+            target_entity="Seller",
+        )
+    except Exception as e:
+        print(f"Warning: Failed to record admin activity: {e}")
+
+    return {
+        "message": "Seller verification updated",
+        "userID": str(seller_id),
+        "isVerified": payload.isVerified,
+    }
 
 
 # ── Reports ───────────────────────────────────────────────────────────────────

--- a/app/backend/models/admin_partner.py
+++ b/app/backend/models/admin_partner.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class SellerVerificationUpdateRequest(BaseModel):
+    isVerified: bool
+
+
+class SellerVerificationUpdateResponse(BaseModel):
+    message: str
+    userID: str
+    isVerified: bool

--- a/app/backend/services/admin_partner_service.py
+++ b/app/backend/services/admin_partner_service.py
@@ -1,0 +1,13 @@
+from database import supabase_admin
+
+
+def update_seller_verification(seller_id: str, is_verified: bool) -> dict | None:
+    response = (
+        supabase_admin.table("Seller")
+        .update({"isVerified": is_verified})
+        .eq("userID", seller_id)
+        .execute()
+    )
+    if not response.data:
+        return None
+    return response.data[0]

--- a/app/frontend/src/api/apis.ts
+++ b/app/frontend/src/api/apis.ts
@@ -92,6 +92,8 @@ export const adminAPI = {
     togglePartnerStatus: (userId: string, isPartner: boolean) => api.put(`/admin/charities/${userId}/partner`, { isPartner }),
     getSellers: () => api.get('/admin/sellers'),
     updateSellerTags: (sellerId: string, tags: string[]) => api.patch(`/admin/sellers/${sellerId}/tags`, tags),
+    updateSellerVerification: (sellerId: string, isVerified: boolean) =>
+        api.put(`/admin/sellers/${sellerId}/verification`, { isVerified }),
     getPendingApprovals: () => api.get('/admin/pending-approvals'),
     getRecentTransactions: (limit = 10) => api.get('/admin/reports/transactions', { params: { limit } }),
     getReportsOverview: () => api.get('/admin/reports/overview'),

--- a/app/frontend/src/components/AdminPartnerTagging.css
+++ b/app/frontend/src/components/AdminPartnerTagging.css
@@ -58,6 +58,7 @@
 }
 
 .pt-badge--seller  { background: rgba(15, 82, 56, 0.9); }
+.pt-badge--verified { background: rgba(15, 82, 56, 0.9); }
 .pt-badge--pending { background: rgba(71, 85, 105, 0.9); }
 
 /* Content column */
@@ -146,6 +147,46 @@
 }
 
 .pt-dots-btn:hover { background: #F1F5F9; }
+
+.pt-menu-wrap {
+  position: relative;
+}
+
+.pt-actions-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 120px;
+  border: 1px solid #E2E8F0;
+  border-radius: 8px;
+  background: #FFFFFF;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+  padding: 6px;
+  z-index: 20;
+}
+
+.pt-actions-menu-btn {
+  width: 100%;
+  border: none;
+  background: #FFFFFF;
+  text-align: left;
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 600;
+  font-size: 12px;
+  color: #191C1A;
+  cursor: pointer;
+}
+
+.pt-actions-menu-btn:hover:not(:disabled) {
+  background: #F8FAFC;
+}
+
+.pt-actions-menu-btn:disabled {
+  color: #94A3B8;
+  cursor: not-allowed;
+}
 
 /* Applied Tags */
 .pt-tags-block {

--- a/app/frontend/src/components/AdminPartnerTagging.tsx
+++ b/app/frontend/src/components/AdminPartnerTagging.tsx
@@ -26,6 +26,7 @@ type SellerRecord = {
     barangay?: string;
     city?: string;
   };
+  isUpdating?: boolean;
 };
 
 export default function AdminPartnerTagging() {
@@ -37,6 +38,7 @@ export default function AdminPartnerTagging() {
   const [untaggedUsers, setUntaggedUsers] = useState(false);
   const [activeTags, setActiveTags] = useState<string[]>([]);
   const [sellerLoading, setSellerLoading] = useState(false);
+  const [openSellerMenuId, setOpenSellerMenuId] = useState<string | null>(null);
 
   // Charity State
   const [charities, setCharities] = useState<CharityWithUser[]>([]);
@@ -75,9 +77,39 @@ export default function AdminPartnerTagging() {
     else fetchCharities();
   }, [mode]);
 
+  useEffect(() => {
+    const handleDocumentClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target?.closest('.pt-menu-wrap')) return;
+      setOpenSellerMenuId(null);
+    };
+
+    document.addEventListener('click', handleDocumentClick);
+    return () => document.removeEventListener('click', handleDocumentClick);
+  }, []);
+
   const updateTags = async (sellerId: string, tags: string[]) => {
     await adminAPI.updateSellerTags(sellerId, tags);
     await loadSellers();
+  };
+
+  const handleToggleSellerVerification = async (sellerId: string, currentStatus: boolean) => {
+    try {
+      setSellers(prev => prev.map(s =>
+        s.userID === sellerId ? { ...s, isUpdating: true } : s
+      ));
+      await adminAPI.updateSellerVerification(sellerId, !currentStatus);
+      setSellers(prev => prev.map(s =>
+        s.userID === sellerId ? { ...s, isVerified: !currentStatus, isUpdating: false } : s
+      ));
+      setOpenSellerMenuId(null);
+    } catch (err) {
+      console.error('Error updating seller verification:', err);
+      alert('Failed to update verification status.');
+      setSellers(prev => prev.map(s =>
+        s.userID === sellerId ? { ...s, isUpdating: false } : s
+      ));
+    }
   };
 
   const handleTogglePartner = async (userId: string, currentStatus: boolean) => {
@@ -164,7 +196,7 @@ export default function AdminPartnerTagging() {
               <div className="pt-card" key={seller.userID}>
                 <div className="pt-img-col">
                   <img src={idx % 2 === 0 ? BakeryImg : CommunityImg} alt={seller.companyName || 'Seller'} className="pt-img" />
-                  <span className={`pt-badge pt-badge--${seller.isVerified ? 'seller' : 'pending'}`}>{seller.isVerified ? 'SELLER' : 'PENDING'}</span>
+                  <span className={`pt-badge pt-badge--${seller.isVerified ? 'verified' : 'pending'}`}>{seller.isVerified ? 'VERIFIED' : 'PENDING'}</span>
                 </div>
 
                 <div className="pt-content">
@@ -183,6 +215,27 @@ export default function AdminPartnerTagging() {
                       <span className={`pt-status-chip pt-status-chip--${seller.isVerified ? 'verified' : 'community'}`}>
                         {seller.isVerified ? 'Verified' : 'Community'}
                       </span>
+                      <div className="pt-menu-wrap">
+                        <button
+                          className="pt-dots-btn"
+                          title="Partner actions"
+                          onClick={() => setOpenSellerMenuId(prev => prev === seller.userID ? null : seller.userID)}
+                          disabled={seller.isUpdating}
+                        >
+                          <span aria-hidden="true">⋮</span>
+                        </button>
+                        {openSellerMenuId === seller.userID && (
+                          <div className="pt-actions-menu">
+                            <button
+                              className="pt-actions-menu-btn"
+                              onClick={() => void handleToggleSellerVerification(seller.userID, !!seller.isVerified)}
+                              disabled={seller.isUpdating}
+                            >
+                              {seller.isUpdating ? 'Updating...' : (seller.isVerified ? 'Unverify' : 'Verify')}
+                            </button>
+                          </div>
+                        )}
+                      </div>
                     </div>
                   </div>
 


### PR DESCRIPTION
Implemented end-to-end seller verify/unverify in Admin Partner Management, with an expandable vertical dropdown action and backend `api > service > model` flow.

### What I changed

1. Backend model layer
- Added [admin_partner.py](c:/Users/Gen/Desktop/SCHOOL/UP/CS%202%20-%20Sem%202/CMSC%20127/Final/sureplus-app/sureplus-app/app/backend/models/admin_partner.py) with:
  - `SellerVerificationUpdateRequest`
  - `SellerVerificationUpdateResponse`

2. Backend service layer
- Added [admin_partner_service.py](c:/Users/Gen/Desktop/SCHOOL/UP/CS%202%20-%20Sem%202/CMSC%20127/Final/sureplus-app/sureplus-app/app/backend/services/admin_partner_service.py):
  - `update_seller_verification(seller_id, is_verified)` updates `Seller.isVerified` safely and returns updated row (or `None`).

3. Backend API layer
- Updated [admin.py](c:/Users/Gen/Desktop/SCHOOL/UP/CS%2020-%20Sem%202/CMSC%20127/Final/sureplus-app/sureplus-app/app/backend/api/admin.py) to include:
  - `PUT /admin/sellers/{seller_id}/verification`
  - Uses request/response models and service call
  - 404 if seller not found
  - admin activity logging (`verify_seller` / `unverify_seller`)

4. Frontend API client
- Updated [apis.ts](c:/Users/Gen/Desktop/SCHOOL/UP/CS%202%20-%20Sem%202/CMSC%20127/Final/sureplus-app/sureplus-app/app/frontend/src/api/apis.ts):
  - Added `adminAPI.updateSellerVerification(sellerId, isVerified)`

5. Admin Partner Tagging UI
- Updated [AdminPartnerTagging.tsx](c:/Users/Gen/Desktop/SCHOOL/UP/CS%202%20-%20Sem%202/CMSC%20127/Final/sureplus-app/sureplus-app/app/frontend/src/components/AdminPartnerTagging.tsx):
  - Added per-seller vertical action button (`⋮`)
  - Expandable dropdown menu (future-ready for more actions)
  - Menu item toggles between `Verify` and `Unverify` based on current `isVerified`
  - Optimistic-safe loading state (`isUpdating`) to prevent double actions/races
  - Click-outside closes dropdown
  - Updated top-left badge text:
    - `PENDING` when not verified
    - `VERIFIED` when verified

6. Styling for dropdown
- Updated [AdminPartnerTagging.css](c:/Users/Gen/Desktop/SCHOOL/UP/CS%202%20-%20Sem%202/CMSC%20127/Final/sureplus-app/sureplus-app/app/frontend/src/components/AdminPartnerTagging.css):
  - Added menu wrapper, popup, and button styles
  - Added `pt-badge--verified` style

### Validation run

- Backend compile check passed:
  - `python -m compileall app/backend`

- Frontend build currently fails due to existing unrelated TS issues in other files (not from this feature), including:
  - `AdminCharityApplications.tsx`
  - `CharityDashboard.tsx`
  - `CharityPostsFeed.tsx`
  - `CreateNewListing.tsx`
  - `EditProfileView.tsx`
  - `HistoryView.tsx`
  - `SalesAnalytics.tsx`

don worry those compile errors are not this commit's fault XD